### PR TITLE
Feature/issue 6 max one empty line

### DIFF
--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -24,55 +24,116 @@ prelude: runOnce -> {
 
 /*
  * ----------------------------------------------------------------------------
- * Workaround for SQLDev 20.2 to fix unwanted indentation of comments
- * original code provided by Vadim Tropashko, 
- * see https://community.oracle.com/thread/4336648
- * This fixes the input source (target.input) and the lexer tokens (target.src).
- * The lexer tokens are used by some parts of the Arbori program.
- * The input source is used after the Arbori program execution.
- * Therefore this fix must run at the beginning of the Arbori program.
+ * Extend (override) "Preserve Original" behaviour of SQLDev to 
+ * replace multiple, consecutive empty lines with one empty line
+ *
+ * To fix unwantend indentation in SQLDev 20.2 (after comments and in other
+ * situations) additionally all spaces and tabs after a newline are removed 
+ * before the first token, but only if the first token is not a comment.
+ * See also original code by Vadim Tropashko, in the SQLDev forum:
+ * https://community.oracle.com/thread/4336648
+ *
+ * It's important to note, that the indentation of comments is not handled
+ * (not supported) by the formatter. This means the original indentation of
+ * commments is left unchanged.
+ *
+ * It's expected that this code must be executed only if 
+ * extraLinesAfterSignificantStatements == oracle.dbtools.app.Format.BreaksX2.keep
+ * in future versions of SQLDev. For SQLDev 20.2 this code must run in any case.
+ * 
+ * This code changes the input source (target.input) and the lexer tokens (target.src).
+ * The lexer tokens are used by some parts of the Arbori program, 
+ * therefore this code must run at the beginning of the Arbori program.
+ * The input source is also used after the Arbori program execution.
  * ----------------------------------------------------------------------------
  */
-fixComments: runOnce -> {
+maxOneEmptyLine: runOnce -> {
   var LexerToken = Java.type('oracle.dbtools.parser.LexerToken'); 
-  var tokens = LexerToken.parse(target.input,true);  // parse with WS symbols
   var Token = Java.type('oracle.dbtools.parser.Token');
   var Substitutions = Java.type('oracle.dbtools.parser.Substitutions');
-  var substitutions = new Substitutions(target.input);
-  var commentEnd = 0;
-  var firstSpace = 0;
-  var removeDuplicateSpace = false;
-  for (i = 0; i < tokens.length; i++) {
-    if (tokens[i].content == "\n") {
-      removeDuplicateSpace = false
-    } else if (removeDuplicateSpace && tokens[i].content == " " && tokens[i-1].content == " ") {
-      // remove duplicate spaces to calculate correct pairwise alignments after removing WS before comments
-      substitutions.put(tokens[i-1].begin,tokens[i].begin,"");
-    }
-    if (tokens[i].type == Token.COMMENT || tokens[i].type == Token.LINE_COMMENT) {
-      // position of comment end
-      commentEnd = tokens[i].end;
-      var firstSpace = 0;
-      continue;
-    }
-    if (tokens[i].content == " " && commentEnd != 0 && firstSpace == 0) {
-      // position of first space after a comment on a new line
-      firstSpace = tokens[i].begin;
-      commentEnd = 0;
-      continue;
-    }
-    if (tokens[i].type != Token.WS) {
-      if (tokens[i].type != Token.COMMENT && tokens[i].type != Token.LINE_COMMENT && firstSpace != 0) {
-        // remove all WS on the subsequent line after a series of comments to enforce correct indentation
-        substitutions.put(firstSpace,tokens[i].begin,"");
-        removeDuplicateSpace = true;
+
+  var removeDuplicateEmptyLines = function() {
+    var tokens = LexerToken.parse(target.input,true);  // parse with WS symbols
+    var substitutions = new Substitutions(target.input);
+    var firstEOLToken = 0;
+    var secondEOLToken = 0;
+    var lastEOLToken = 0;
+    for (i = 0; i < tokens.length; i++) {
+      if (tokens[i].type == Token.LINE_COMMENT && firstEOLToken == 0) {
+        firstEOLToken = tokens[i];
+        continue;
       }
-      firstSpace = 0;          
-      commentEnd = 0;
+      if (tokens[i].content == "\n") {
+        if (firstEOLToken == 0) {
+          firstEOLToken = tokens[i];
+        } else if (secondEOLToken == 0) {
+          secondEOLToken = tokens[i];
+        } else {
+          lastEOLToken = tokens[i];
+        }
+        continue;
+      }
+      if (tokens[i].type != Token.WS) {
+        if (lastEOLToken != 0) {
+          substitutions.put(secondEOLToken.begin,lastEOLToken.begin,"");
+        } 
+        firstEOLToken = 0;
+        secondEOLToken = 0;
+        lastEOLToken = 0;
+      }
     }
+    // update source code
+    target.input = substitutions.transformInput();
   }
-  // update source code
-  target.input = substitutions.transformInput();
+
+  var removeWSBeforeFirstTokenInLine = function() {
+    var tokens = LexerToken.parse(target.input,true);  // parse with WS symbols
+    var substitutions = new Substitutions(target.input);
+    var eolToken = 0
+    for (i = 0; i < tokens.length; i++) {
+      if (tokens[i].type == Token.LINE_COMMENT || tokens[i].content == "\n") {
+        eolToken = tokens[i];
+        continue;
+      }
+      if (tokens[i].type != Token.WS) {
+        if (eolToken != 0 && tokens[i].type != Token.COMMENT) {
+          substitutions.put(eolToken.end,tokens[i].begin,"");
+        }
+        eolToken = 0;
+      }
+    }
+    // update source code
+    target.input = substitutions.transformInput();
+  }
+
+  var removeWSOnEmptyLines = function() {
+    var tokens = LexerToken.parse(target.input,true);  // parse with WS symbols
+    var substitutions = new Substitutions(target.input);
+    var eolToken = 0
+    for (i = 0; i < tokens.length; i++) {
+      if (tokens[i].type != Token.WS) {
+        eolToken = 0;
+        continue;
+      }
+      if (eolToken == 0 && (tokens[i].type == Token.LINE_COMMENT || tokens[i].content == "\n")) {
+        eolToken = tokens[i];
+        continue;
+      }
+      if (tokens[i].content == "\n") {
+        if (eolToken != 0) {
+          substitutions.put(eolToken.end,tokens[i].begin,"");
+        }
+        eolToken = tokens[i];
+      }
+    }
+    // update source code
+    target.input = substitutions.transformInput();
+  }
+
+  // replacements
+  removeDuplicateEmptyLines();
+  removeWSBeforeFirstTokenInLine();
+  removeWSOnEmptyLines();
 
   // tokens without WS and comments (mimicking default behaviour)
   var Lexer = Java.type('oracle.dbtools.parser.Lexer');

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_6_max_one_empty_line.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_6_max_one_empty_line.xtend
@@ -1,0 +1,94 @@
+package com.trivadis.plsql.formatter.settings.tests
+
+import com.trivadis.plsql.formatter.settings.ConfiguredTestFormatter
+import oracle.dbtools.app.Format
+import oracle.dbtools.app.Format.BreaksX2
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class Issue_6_max_one_empty_line extends ConfiguredTestFormatter {
+
+    @Before
+    def void setup() {
+        formatter.options.put(formatter.extraLinesAfterSignificantStatements, BreaksX2.Keep);
+        formatter.options.put(formatter.kwCase, Format.Case.NoCaseChange)
+    }
+
+    @Test
+    def pkg() {
+        val input = '''
+            /*
+             * comment before pkg
+             */
+            create or replace package pkg is
+               
+                 
+                /*
+                 * pkg
+                 */
+                      
+                               
+                                              
+                /*
+                 * p1
+                 */
+                procedure p1;
+                procedure p2;
+                
+                
+                procedure p3;
+                
+                
+                    -- p4 (1)  
+                    
+                 
+                    
+                  -- p4 (2)
+                
+                
+                
+                procedure p4;
+                
+                
+                -- p5
+                procedure p5;
+                
+            end pkg;
+            /
+        '''
+        val expected = '''
+            /*
+             * comment before pkg
+             */
+            create or replace package pkg is
+
+                /*
+                 * pkg
+                 */
+
+                /*
+                 * p1
+                 */
+               procedure p1;
+               procedure p2;
+
+               procedure p3;
+
+                    -- p4 (1)  
+
+                  -- p4 (2)
+
+               procedure p4;
+
+                -- p5
+               procedure p5;
+
+            end pkg;
+            /
+        '''.toString.trim
+        val actual = formatter.format(input)
+        Assert.assertEquals(expected, actual)
+    }
+
+}


### PR DESCRIPTION
Fixes #6 by removing duplicate empty lines and keeping only one empty line with "Preserve Original"
Fixes #16 by removing leading white space for all non-comment lines to avoid unwanted indentations with "Preserve Original"