### PR TITLE
Feature/issue 19 break args

### DIFF
--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -149,50 +149,6 @@ maxOneEmptyLine: runOnce -> {
   target.src.addAll(newTarget.src);
 }
 
--- salvisberg: added to identifiy splittable argument lists with >= 5 arguments to solve issue #19
-splittableArgList:
-  [parent) paren_expr_list 
-    & [arg1) arg_list 
-    & arg1^ = parent
-    & [arg2) arg_list 
-    & arg2^ = arg1
-    & [arg3) arg_list 
-    & arg3^ = arg2
-    & [arg4) arg_list 
-    & arg4^ = arg3
-;
-
--- salvisberg: added to identifiy splittable expression lists with >= 5 arguments to solve issue #19
-splittableExprList:
-  [parent) "(x,y,z)" 
-    & [arg1) "expr_list" 
-    & parent < arg1
-    & [arg2) "expr_list" 
-    & arg2^ = arg1
-    & [arg3) "expr_list" 
-    & arg3^ = arg2
-    & [arg4) "expr_list" 
-    & arg4^ = arg3
-    & [arg5) "expr_list" 
-    & arg5^ = arg4
-;
-
--- salvisberg: added to identifiy splittable arg (issue #19)
-splitArg:
-  .breaksProcArgs & [node) arg & ![node) assoc_arg & splittableArgList.parent < node
-;
-
--- salvisberg: added to identifiy splittable expr (issue #19)
-splitExpr:
-  .breaksProcArgs & [node) expr & ![node^) assoc_arg & splittableExprList.parent < node
-;
-
--- salvisberg: expression to be added to indentedNodes1 as single condition (issue #19)
-splitArguments:
-    splitArg
-  | splitExpr
-;
-
 /**
  * simpleIndentConditions  
  * Parse nodes to be indented with simple conditions, typically parse node payload, e.g.
@@ -459,10 +415,7 @@ ancestor < node & ![node^) "(x,y,z)" & [node) column  & (
 );
 
 
-indentedNodes1: 
-    simpleIndentConditions 
-  | closestAncestorDescendent 
-  | splitArguments              -- salvisberg: added to solve issue #19
+indentedNodes1: simpleIndentConditions | closestAncestorDescendent
 ->
 ;
 
@@ -474,6 +427,86 @@ indentedNodes2: indentedNodes1
 ->
 ;
 
+/**
+ * salvisberg: start section "split arguments"
+ *
+ * Add line breaks if argument and expression lists have more than 4 argurments.
+ * Must run at this position where all other split and indentations are handled.
+ * Calling indentedNodes1 and indentedNodes2 manually due to Arbori query limitations.
+ * Solves issues #19 
+ */
+
+allArgList:
+  [parent) paren_expr_list
+;
+
+splittableArgList:
+  [parent) paren_expr_list 
+    & [arg1) arg_list 
+    & arg1^ = parent
+    & [arg2) arg_list 
+    & arg2^ = arg1
+    & [arg3) arg_list 
+    & arg3^ = arg2
+    & [arg4) arg_list 
+    & arg4^ = arg3
+;
+
+allExprList:
+  [parent) "(x,y,z)"
+;
+
+splittableExprList:
+  [parent) "(x,y,z)" 
+    & [arg1) "expr_list" 
+    & parent < arg1
+    & [arg2) "expr_list" 
+    & arg2^ = arg1
+    & [arg3) "expr_list" 
+    & arg3^ = arg2
+    & [arg4) "expr_list" 
+    & arg4^ = arg3
+    & [arg5) "expr_list" 
+    & arg5^ = arg4
+;
+
+splitArg:
+  .breaksProcArgs 
+    & [node) arg 
+    & ![node) assoc_arg 
+    & allArgList.parent < node
+    & splittableArgList.parent < node
+  -> {
+    // filter via JavaScript since "allArgList.parent = splittableArgList.parent" does not work as Arbori condition
+    var all = tuple.get("allArgList.parent");
+    var splittable = tuple.get("splittableArgList.parent");
+    if (all == splittable) {
+      struct.indentedNodes1(target, tuple);
+      struct.indentedNodes2(target, tuple);
+    }
+  }
+;
+
+splitExpr:
+  .breaksProcArgs 
+    & [node) expr 
+    & ![node) assoc_arg 
+    & allExprList.parent < node
+    & splittableExprList.parent < node
+  -> {
+    // filter via JavaScript since "allExprList.parent.parent = splittableExprList.parent" does not work as Arbori condition
+    var all = tuple.get("allExprList.parent");
+    var splittable = tuple.get("splittableExprList.parent");
+    if (all == splittable) {
+      struct.indentedNodes1(target, tuple);
+      struct.indentedNodes2(target, tuple);
+    }
+  }
+;
+
+/**
+ * salvisberg: stop section "split arguments"
+ */
 
 /**
  * The skipWhiteSpaceBeforeNode and skipWhiteSpaceBeforeNode are

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -149,6 +149,50 @@ maxOneEmptyLine: runOnce -> {
   target.src.addAll(newTarget.src);
 }
 
+-- salvisberg: added to identifiy splittable argument lists with >= 5 arguments to solve issue #19
+splittableArgList:
+  [parent) paren_expr_list 
+    & [arg1) arg_list 
+    & arg1^ = parent
+    & [arg2) arg_list 
+    & arg2^ = arg1
+    & [arg3) arg_list 
+    & arg3^ = arg2
+    & [arg4) arg_list 
+    & arg4^ = arg3
+;
+
+-- salvisberg: added to identifiy splittable expression lists with >= 5 arguments to solve issue #19
+splittableExprList:
+  [parent) "(x,y,z)" 
+    & [arg1) "expr_list" 
+    & parent < arg1
+    & [arg2) "expr_list" 
+    & arg2^ = arg1
+    & [arg3) "expr_list" 
+    & arg3^ = arg2
+    & [arg4) "expr_list" 
+    & arg4^ = arg3
+    & [arg5) "expr_list" 
+    & arg5^ = arg4
+;
+
+-- salvisberg: added to identifiy splittable arg (issue #19)
+splitArg:
+  .breaksProcArgs & [node) arg & ![node) assoc_arg & splittableArgList.parent < node
+;
+
+-- salvisberg: added to identifiy splittable expr (issue #19)
+splitExpr:
+  .breaksProcArgs & [node) expr & ![node^) assoc_arg & splittableExprList.parent < node
+;
+
+-- salvisberg: expression to be added to indentedNodes1 as single condition (issue #19)
+splitArguments:
+    splitArg
+  | splitExpr
+;
+
 /**
  * simpleIndentConditions  
  * Parse nodes to be indented with simple conditions, typically parse node payload, e.g.
@@ -415,7 +459,10 @@ ancestor < node & ![node^) "(x,y,z)" & [node) column  & (
 );
 
 
-indentedNodes1: simpleIndentConditions | closestAncestorDescendent
+indentedNodes1: 
+    simpleIndentConditions 
+  | closestAncestorDescendent 
+  | splitArguments              -- salvisberg: added to solve issue #19
 ->
 ;
 

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_19.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_19.xtend
@@ -1,0 +1,64 @@
+package com.trivadis.plsql.formatter.settings.tests
+
+import com.trivadis.plsql.formatter.settings.ConfiguredTestFormatter
+import org.junit.Test
+
+class Issue_19 extends ConfiguredTestFormatter {
+    
+    @Test
+    def arg_list_split_5_or_more_params() {
+        '''
+            BEGIN
+               f();
+               f(1);
+               f(1, 2);
+               f(1, 2, 3);
+               f(1, 2, 3, 4);
+               f(
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+               );
+               f(
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6
+               );
+            END;
+            /
+        '''.formatAndAssert
+    }
+
+    @Test
+    def expr_list_split_5_or_more_params() {
+        '''
+            SELECT f(),
+                   f(1),
+                   f(1, 2),
+                   f(1, 2, 3),
+                   f(1, 2, 3, 4),
+                   f(
+                      1,
+                      2,
+                      3,
+                      4,
+                      5
+                   ),
+                   f(
+                      1,
+                      2,
+                      3,
+                      4,
+                      5,
+                      6
+                   )
+              FROM dual;
+        '''.formatAndAssert
+    }
+
+}

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_19.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_19.xtend
@@ -61,4 +61,34 @@ class Issue_19 extends ConfiguredTestFormatter {
         '''.formatAndAssert
     }
 
+    @Test
+    def nested_arg_list() {
+        '''
+            BEGIN
+               f(
+                  f(1),
+                  f(1, 2),
+                  f(1, 2, 3),
+                  f(1, 2, 3, 4),
+                  f(1, 2, 3, 4, 5),
+               );
+            END;
+            /
+        '''.formatAndAssert
+    }
+
+    @Test
+    def nested_expr_list() {
+        '''
+            SELECT f(
+                      f(1),
+                      f(1, 2),
+                      f(1, 2, 3),
+                      f(1, 2, 3, 4),
+                      f(1, 2, 3, 4, 5)
+                   ),
+              FROM dual;
+        '''.formatAndAssert
+    }
+
 }

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_19.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_19.xtend
@@ -70,7 +70,13 @@ class Issue_19 extends ConfiguredTestFormatter {
                   f(1, 2),
                   f(1, 2, 3),
                   f(1, 2, 3, 4),
-                  f(1, 2, 3, 4, 5),
+                  f(
+                     1,
+                     2,
+                     3,
+                     4,
+                     5
+                  )
                );
             END;
             /
@@ -85,8 +91,14 @@ class Issue_19 extends ConfiguredTestFormatter {
                       f(1, 2),
                       f(1, 2, 3),
                       f(1, 2, 3, 4),
-                      f(1, 2, 3, 4, 5)
-                   ),
+                      f(
+                         1,
+                         2,
+                         3,
+                         4,
+                         5
+                      )
+                   )
               FROM dual;
         '''.formatAndAssert
     }

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Paren_expr_list.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Paren_expr_list.xtend
@@ -8,7 +8,17 @@ class Paren_expr_list extends ConfiguredTestFormatter {
     @Test
     def unnamed_parameters() {
         '''
-            SELECT func(a, b, c, 100, 200, 300, 400, 500)
+            SELECT func(a, b, c, 100),
+                   func(
+                      a,
+                      b,
+                      c,
+                      100,
+                      200,
+                      300,
+                      400,
+                      500
+                   )
               FROM dual;
         '''.formatAndAssert
     }


### PR DESCRIPTION
Add line breaks for argument lists and expression lists with more than 4 arguments.
Fixes #19