### PR TITLE
Bugfix/issue 36 conditional compilation

### DIFF
--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -96,7 +96,7 @@ maxOneEmptyLine: runOnce -> {
         continue;
       }
       if (tokens[i].type != Token.WS) {
-        if (eolToken != 0 && tokens[i].type != Token.COMMENT) {
+        if (eolToken != 0 && tokens[i].type != Token.COMMENT && tokens[i].type != Token.MACRO_SKIP) {
           substitutions.put(eolToken.end,tokens[i].begin,"");
         }
         eolToken = 0;

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -1207,4 +1207,40 @@ indentCaseExpression:
       }
     }
   }
+
+  indentTokensOnNewLineOfFirstSelectionDirective: runOnce -> {
+    var LexerToken = Java.type('oracle.dbtools.parser.LexerToken'); 
+    var Token = Java.type('oracle.dbtools.parser.Token');
+    var tokens = LexerToken.parse(target.input,true);  // parse with WS symbols
+    var indentSpaces = struct.options.get("identSpaces")
+    var addIndent = ""
+    for (j = 0; j < indentSpaces; j++) {
+      addIndent = addIndent + " ";
+    }
+    var pos = 0;
+    var withinFirstBranch = false;
+    for (i = 0; i < tokens.length; i++) {
+      if (tokens[i].type == Token.MACRO_SKIP && tokens[i].content.toLowerCase().startsWith("$if ")) {
+        withinFirstBranch = true;
+        logger.fine(struct.getClass(), "--- withinFirstBranch = true ---");
+        continue;
+      }
+      if (withinFirstBranch && tokens[i].type == Token.MACRO_SKIP && tokens[i].content.startsWith("$")) {
+        withinFirstBranch = false;
+        logger.fine(struct.getClass(), "--- withinFirstBranch = false ---");
+        continue;
+      }
+      if (tokens[i].type != Token.WS && tokens[i].type != Token.MACRO_SKIP && tokens[i].type != Token.COMMENT && tokens[i].type != Token.LINE_COMMENT) {
+        if (withinFirstBranch) {
+          var nodeIndent = struct.getNewline(pos);
+          if (nodeIndent != null && nodeIndent.contains("\n")) {
+            logger.fine(struct.getClass(), "pos: " + pos + " type: " + tokens[i].type + " content: " + tokens[i].content + " nodeIndent.length: " + nodeIndent.length);
+            struct.putNewline(pos, nodeIndent + addIndent);
+          }
+        }
+        pos++;
+      }
+    }
+  }
+
 ;

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -1085,7 +1085,6 @@ less2Spaces:   :breaksBeforeComma & (
   | [node+1) prm_spec & [node) ',' 
   | [node+1) select_term & [node) ',' 
   | [node+1) name & [node) ','                  -- salvisberg: added to handle into clause (#30)
-  | [node+1) name_item & [node) ','             -- salvisberg: added to handle into clause (#30)
   | [node+1) group_by_col & [node) ','               
   | [node+1) "ord_by_1desc" & [node) ','             
   | [node+1) table_reference & [node) ',' 

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/ConfiguredTestFormatter.java
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/ConfiguredTestFormatter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
+import java.util.logging.LogManager;
 
 import org.junit.Assert;
 
@@ -16,8 +17,18 @@ public abstract class ConfiguredTestFormatter {
 
     public ConfiguredTestFormatter() {
         super();
+        loadLoggingConf();
         formatter = new Format();
         configureFormatter();
+    }
+    
+    private void loadLoggingConf() {
+        LogManager manager = LogManager.getLogManager();
+        try {
+            manager.readConfiguration(Thread.currentThread().getContextClassLoader().getResourceAsStream("logging.conf"));
+        } catch (SecurityException | IOException e) {
+            e.printStackTrace();
+        }
     }
 
     private Map<String, Object> getOptions() {

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_36.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_36.xtend
@@ -1,0 +1,85 @@
+package com.trivadis.plsql.formatter.settings.tests
+
+import com.trivadis.plsql.formatter.settings.ConfiguredTestFormatter
+import org.junit.Test
+
+class Issue_36 extends ConfiguredTestFormatter {
+    
+    @Test
+    def if_only() {
+        '''
+            CREATE OR REPLACE PROCEDURE p IS
+            BEGIN
+               -- comment 1
+               $IF DBMS_DB_VERSION.VER_LE_12_2 $THEN
+                  -- comment 2
+                  dbms_output.put_line('older: first line');
+                  dbms_output.put_line('older: second line');
+               $END
+            END;
+            /
+        '''.formatAndAssert
+    }
+
+
+    @Test
+    def if_else() {
+        '''
+            CREATE OR REPLACE PROCEDURE p IS
+            BEGIN
+               -- comment 1
+               $IF DBMS_DB_VERSION.VER_LE_12_2 $THEN
+                  -- comment 2
+                  dbms_output.put_line('older');
+               $ELSE
+                  -- comment 3
+                  dbms_output.put_line('newer');
+               $END
+            END;
+            /
+        '''.formatAndAssert
+    }
+
+    @Test
+    def if_elsif_else() {
+        '''
+            CREATE OR REPLACE PROCEDURE p IS
+            BEGIN
+               -- comment 1
+               $IF DBMS_DB_VERSION.VER_LE_12_2 $THEN
+                  -- comment 2
+                  dbms_output.put_line('older');
+               $ELSIF DBMS_DB_VERSION.VER_LE_18 $THEN
+                  -- comment 3
+                  dbms_output.put_line('newer');
+               $ELSE
+                  -- comment 4
+                  dbms_output.put_line('newest');
+               $END
+            END;
+            /
+        '''.formatAndAssert
+    }
+
+    @Test
+    def false_if_elsif_else_lower() {
+        '''
+            CREATE OR REPLACE PROCEDURE p IS
+            BEGIN
+               -- comment 1
+               $if false $then
+                  -- comment 2
+                  dbms_output.put_line('false');
+               $elsif DBMS_DB_VERSION.VER_LE_18 $then
+                  -- comment 3
+                  dbms_output.put_line('18c');
+               $else
+                  -- comment 4
+                  dbms_output.put_line('newer than 18c');
+               $end
+            END;
+            /
+        '''.formatAndAssert
+    }
+
+}


### PR DESCRIPTION
Fixes #36 preserve indentation of conditional compilation tokens  and indent statements in first selection directive branch which are part of the parse tree regardless of the condition