### PR TITLE
Feature/issue 41 xml param

### DIFF
--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -27,56 +27,67 @@ var getFiles = function (rootPath, extensions) {
     return files;
 }
 
-var configure = function (formatter, arboriPath) {
+var configure = function (formatter, xmlPath, arboriPath) {
     var File = Java.type("java.io.File");
     var Format = Java.type("oracle.dbtools.app.Format");
     var arboriFileName = arboriPath;
+    if (!"default".equals(xmlPath) && !"embedded".equals(xmlPath) && xmlPath != null) {
+        var Persist2XML = Java.type("oracle.dbtools.app.Persist2XML");
+        var url = new File(xmlPath).toURI().toURL();
+        var options = Persist2XML.read(url);
+        var Collectors = Java.type("java.util.stream.Collectors");
+        var keySet = options.keySet().stream().collect(Collectors.toList());
+        for (var j in keySet) {
+            formatter.options.put(keySet[j], options.get(keySet[j]));
+        }
+    } else if ("embedded".equals(xmlPath)) {
+        // General
+        formatter.options.put(formatter.kwCase, Format.Case.UPPER);                                     // default: Format.Case.UPPER
+        formatter.options.put(formatter.idCase, Format.Case.NoCaseChange);                              // default: Format.Case.lower
+        formatter.options.put(formatter.singleLineComments, Format.InlineComments.CommentsUnchanged);   // default: Format.InlineComments.CommentsUnchanged
+        // Alignment
+        formatter.options.put(formatter.alignTabColAliases, false);                                     // default: true
+        formatter.options.put(formatter.alignTypeDecl, true);                                           // default: true
+        formatter.options.put(formatter.alignNamedArgs, true);                                          // default: true
+        formatter.options.put(formatter.alignAssignments, true);                                        // default: false
+        formatter.options.put(formatter.alignEquality, false);                                          // default: false
+        formatter.options.put(formatter.alignRight, true);                                              // default: false
+        // Indentation
+        formatter.options.put(formatter.identSpaces, 3);                                                // default: 3
+        formatter.options.put(formatter.useTab, false);                                                 // default: false
+        // Line Breaks
+        formatter.options.put(formatter.breaksComma, Format.Breaks.After);                              // default: Format.Breaks.After
+        formatter.options.put("commasPerLine", 1);                                                      // default: 5
+        formatter.options.put(formatter.breaksConcat, Format.Breaks.Before);                            // default: Format.Breaks.Before
+        formatter.options.put(formatter.breaksAroundLogicalConjunctions, Format.Breaks.Before);         // default: Format.Breaks.Before
+        formatter.options.put(formatter.breakAnsiiJoin, true);                                          // default: false
+        formatter.options.put(formatter.breakParenCondition, true);                                     // default: false
+        formatter.options.put(formatter.breakOnSubqueries, true);                                       // default: true
+        formatter.options.put(formatter.maxCharLineSize, 120);                                          // default: 128
+        formatter.options.put(formatter.forceLinebreaksBeforeComment, false);                           // default: false
+        formatter.options.put(formatter.extraLinesAfterSignificantStatements, Format.BreaksX2.X1);      // default: Format.BreaksX2.X2
+        formatter.options.put(formatter.breaksAfterSelect, false);                                      // default: true
+        formatter.options.put(formatter.flowControl, Format.FlowControl.IndentedActions);               // default: Format.FlowControl.IndentedActions
+        // White Space
+        formatter.options.put(formatter.spaceAroundOperators, true);                                    // default: true
+        formatter.options.put(formatter.spaceAfterCommas, true);                                        // default: true
+        formatter.options.put(formatter.spaceAroundBrackets, Format.Space.Default);                     // default: Format.Space.Default
+        // Hidden, not configurable in the GUI preferences dialog of SQLDev 20.2
+        formatter.options.put(formatter.breaksProcArgs, false);                                         // default: false (overridden in Arbori program based on other settings)
+        formatter.options.put(formatter.adjustCaseOnly, false);                                         // default: false (set true to skip formatting)
+        formatter.options.put(formatter.formatThreshold, 1);                                            // default: 1 (disables deprecated post-processing logic)
+    }
     if (!"default".equals(arboriPath)) {
         arboriFileName = new File(arboriPath).getAbsolutePath();
     }
-    // General
-    formatter.options.put(formatter.kwCase, Format.Case.UPPER);                                     // default: Format.Case.UPPER
-    formatter.options.put(formatter.idCase, Format.Case.NoCaseChange);                              // default: Format.Case.lower
-    formatter.options.put(formatter.singleLineComments, Format.InlineComments.CommentsUnchanged);   // default: Format.InlineComments.CommentsUnchanged
-    // Alignment
-    formatter.options.put(formatter.alignTabColAliases, false);                                     // default: true
-    formatter.options.put(formatter.alignTypeDecl, true);                                           // default: true
-    formatter.options.put(formatter.alignNamedArgs, true);                                          // default: true
-    formatter.options.put(formatter.alignAssignments, true);                                        // default: false
-    formatter.options.put(formatter.alignEquality, false);                                          // default: false
-    formatter.options.put(formatter.alignRight, true);                                              // default: false
-    // Indentation
-    formatter.options.put(formatter.identSpaces, 3);                                                // default: 3
-    formatter.options.put(formatter.useTab, false);                                                 // default: false
-    // Line Breaks
-    formatter.options.put(formatter.breaksComma, Format.Breaks.After);                              // default: Format.Breaks.After
-    formatter.options.put("commasPerLine", 1);                                                      // default: 5
-    formatter.options.put(formatter.breaksConcat, Format.Breaks.Before);                            // default: Format.Breaks.Before
-    formatter.options.put(formatter.breaksAroundLogicalConjunctions, Format.Breaks.Before);         // default: Format.Breaks.Before
-    formatter.options.put(formatter.breakAnsiiJoin, true);                                          // default: false
-    formatter.options.put(formatter.breakParenCondition, true);                                     // default: false
-    formatter.options.put(formatter.breakOnSubqueries, true);                                       // default: true
-    formatter.options.put(formatter.maxCharLineSize, 120);                                          // default: 128
-    formatter.options.put(formatter.forceLinebreaksBeforeComment, false);                           // default: false
-    formatter.options.put(formatter.extraLinesAfterSignificantStatements, Format.BreaksX2.X1);      // default: Format.BreaksX2.X2
-    formatter.options.put(formatter.breaksAfterSelect, false);                                      // default: true
-    formatter.options.put(formatter.flowControl, Format.FlowControl.IndentedActions);               // default: Format.FlowControl.IndentedActions
-    // White Space
-    formatter.options.put(formatter.spaceAroundOperators, true);                                    // default: true
-    formatter.options.put(formatter.spaceAfterCommas, true);                                        // default: true
-    formatter.options.put(formatter.spaceAroundBrackets, Format.Space.Default);                     // default: Format.Space.Default
-    // Hidden, not configurable in the GUI preferences dialog of SQLDev 20.2
-    formatter.options.put(formatter.breaksProcArgs, false);                                         // default: false (overridden in Arbori program based on other settings)
-    formatter.options.put(formatter.adjustCaseOnly, false);                                         // default: false (set true to skip formatting)
-    formatter.options.put(formatter.formatThreshold, 1);                                            // default: 1 (disables deprecated post-processing logic)
     // Custom Format
-    formatter.options.put(formatter.formatProgramURL, arboriFileName);                              // default: "default" (= provided by SQLDev / SQLcl)
+    formatter.options.put(formatter.formatProgramURL, arboriFileName);                                  // default: "default" (= provided by SQLDev / SQLcl)
 }
 
-var getConfiguredFormatter = function (arboriPath) {
+var getConfiguredFormatter = function (xmlPath, arboriPath) {
     var Format = Java.type("oracle.dbtools.app.Format")
     var formatter = new Format();
-    configure(formatter, arboriPath);
+    configure(formatter, xmlPath, arboriPath);
     return formatter;
 }
 
@@ -130,19 +141,26 @@ var printUsage = function () {
     ctx.write("  <rootPath>     path to directory containing files to format (content will be replaced!)\n\n");
     ctx.write("options:\n");
     ctx.write("  ext=<ext>      comma separated list of file extensions to process, e.g. ext=sql,pks,pkb\n");
+    ctx.write("  xml=<file>     path to the file containing the xml file for advanced format settings\n");
     ctx.write("  arbori=<file>  path to the file containing the Arbori program for custom format settings\n\n");
+}
+
+var getPrefix = function() {
+    var suffix = "format";
+    if (args[0].endsWith(".js")) {
+        suffix += ".js";
+    }
+    return args[0].replace(suffix, "");
 }
 
 var processAndValidateArgs = function () {
     if (args.length < 2) {
         ctx.write("missing mandatory <rootPath> argument.\n\n");
-        printUsage();
         return false;
     }
     rootPath = args[1];
     if (!existsDirectory(rootPath)) {
         ctx.write("directory " + rootPath + " does not exist.\n\n");
-        printUsage();
         return false;
     }
     for (var i = 2; i < args.length; i++) {
@@ -153,17 +171,23 @@ var processAndValidateArgs = function () {
             }
             continue;
         }
+        if (args[i].startsWith("xml=")) {
+            xmlPath = args[i].substring(4);
+            if (!"default".equals(xmlPath) && !"embedded".equals(xmlPath) && !existsFile(xmlPath)) {
+                ctx.write("file " + xmlPath + " does not exist.\n\n");
+                return false;
+            }
+            continue;
+        }
         if (args[i].startsWith("arbori=")) {
             arboriPath = args[i].substring(7);
             if (!"default".equals(arboriPath) && !existsFile(arboriPath)) {
                 ctx.write("file " + arboriPath + " does not exist.\n\n");
-                printUsage();
                 return false;
             }
             continue;
         }
         ctx.write("invalid argument " + args[i] + ".\n\n");
-        printUsage();
         return false;
     }
     if (extensions.size() == 0) {
@@ -173,12 +197,15 @@ var processAndValidateArgs = function () {
             extensions.add("." + defaults[i]);
         }
     }
-    if (arboriPath == null) {
-        var suffix = "format";
-        if (args[0].endsWith(".js")) {
-            suffix += ".js";
+    if (xmlPath == null) {
+        xmlPath = getPrefix() + "../settings/sql_developer/trivadis_advanced_format.xml"
+        if (!existsFile(xmlPath)) {
+            ctx.write('Warning: ' + xmlPath + ' not found, using "embedded" instead.\n\n');
+            xmlPath = "embedded"; 
         }
-        arboriPath = args[0].replace(suffix, "") + "../settings/sql_developer/trivadis_custom_format.arbori"
+    }
+    if (arboriPath == null) {
+        arboriPath = getPrefix() + "../settings/sql_developer/trivadis_custom_format.arbori"
         if (!existsFile(arboriPath)) {
             ctx.write('Warning: ' + arboriPath + ' not found, using "default" instead.\n\n');
             arboriPath = "default"; 
@@ -192,10 +219,13 @@ var ArrayList = Java.type("java.util.ArrayList");
 printHeader();
 var rootPath = null;
 var extensions = new ArrayList();
+var xmlPath = null;
 var arboriPath = null;
-if (processAndValidateArgs()) {
+if (!processAndValidateArgs()) {
+    printUsage();
+} else {
     var files = getFiles(rootPath, extensions);
-    var formatter = getConfiguredFormatter(arboriPath);
+    var formatter = getConfiguredFormatter(xmlPath, arboriPath);
     for (var i in files) {
         ctx.write("Formatting file " + (i+1) + " of " + files.length + ": " + files[i].toString() + "... ");
         ctx.getOutputStream().flush();

--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -142,7 +142,10 @@ var printUsage = function () {
     ctx.write("options:\n");
     ctx.write("  ext=<ext>      comma separated list of file extensions to process, e.g. ext=sql,pks,pkb\n");
     ctx.write("  xml=<file>     path to the file containing the xml file for advanced format settings\n");
-    ctx.write("  arbori=<file>  path to the file containing the Arbori program for custom format settings\n\n");
+    ctx.write("                 xml=default used default advanced settings included in sqlcl\n");
+    ctx.write("                 xml=embedded used advanced settings defined in format.js\n");
+    ctx.write("  arbori=<file>  path to the file containing the Arbori program for custom format settings\n");
+    ctx.write("                 arbori=default uses default Arbori program included in sqlcl\n\n");
 }
 
 var getPrefix = function() {

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatTest.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatTest.xtend
@@ -121,7 +121,7 @@ class FormatTest extends AbstractSqlclTest {
     }
     
     @Test
-    def void process_pkb_with_original_arbori() {
+    def void process_with_original_arbori() {
         // run
         val actual = runScript(tempDir.toString(), "arbori=" + File.getResource("/original/20.2.0/custom_format.arbori").path)
         Assert.assertTrue(actual.contains("package_body.pkb"))
@@ -182,7 +182,7 @@ class FormatTest extends AbstractSqlclTest {
     }
 
     @Test
-    def void process_pkb_with_default_arbori() {
+    def void process_with_default_arbori() {
         // run
         val actual = runScript(tempDir.toString(), "arbori=default")
         Assert.assertTrue(actual.contains("package_body.pkb"))

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatTest.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatTest.xtend
@@ -243,4 +243,128 @@ class FormatTest extends AbstractSqlclTest {
         Assert.assertEquals(expectedQuery, actualQuery)
     }
 
+    @Test
+    def void process_with_xml() {
+        // run
+        val actual = runScript(tempDir.toString(), "xml=" + File.getResource("/advanced_format.xml").path)
+        Assert.assertTrue(actual.contains("package_body.pkb"))
+        Assert.assertTrue(actual.contains("query.sql"))
+
+        // package_body.pkb
+        val expectedPackageBody = '''
+            CREATE OR REPLACE PACKAGE BODY the_api.math AS
+               FUNCTION to_int_table (
+                  in_integers  IN  VARCHAR2
+                , in_pattern   IN  VARCHAR2 DEFAULT '[0-9]+'
+               ) RETURN sys.ora_mining_number_nt
+                  DETERMINISTIC
+                  ACCESSIBLE BY ( PACKAGE the_api.math, PACKAGE the_api.test_math )
+               IS
+                  l_result  sys.ora_mining_number_nt := sys.ora_mining_number_nt();
+                  l_pos     INTEGER := 1;
+                  l_int     INTEGER;
+               BEGIN
+                  <<integer_tokens>>
+                  LOOP
+                     l_int               := to_number(regexp_substr(in_integers, in_pattern, 1, l_pos));
+                     EXIT integer_tokens WHEN l_int IS NULL;
+                     l_result.extend;
+                     l_result(l_pos)     := l_int;
+                     l_pos               := l_pos + 1;
+                  END LOOP integer_tokens;
+                  RETURN l_result;
+               END to_int_table;
+            END math;
+            /
+        '''.toString.trim
+        val actualPackageBody = getFormattedContent("package_body.pkb")
+        Assert.assertEquals(expectedPackageBody, actualPackageBody)
+ 
+        // query.sql
+        val expectedQuery = '''
+            SELECT d.department_name
+                 , v.employee_id
+                 , v.last_name
+              FROM departments d CROSS APPLY (
+                      SELECT *
+                        FROM employees e
+                       WHERE e.department_id = d.department_id
+                   ) v
+             WHERE d.department_name IN (
+                      'Marketing'
+                    , 'Operations'
+                    , 'Public Relations'
+                   )
+             ORDER BY d.department_name
+                    , v.employee_id;
+        '''.toString.trim
+        val actualQuery = getFormattedContent("query.sql")
+        Assert.assertEquals(expectedQuery, actualQuery)
+    }
+
+    @Test
+    def void process_with_default_xml_default_arbori() {
+        // run
+        val actual = runScript(tempDir.toString(), "xml=default", "arbori=default")
+        Assert.assertTrue(actual.contains("package_body.pkb"))
+        Assert.assertTrue(actual.contains("query.sql"))
+
+        // package_body.pkb
+        val expectedPackageBody = '''
+            CREATE OR REPLACE PACKAGE BODY the_api.math AS
+            
+                FUNCTION to_int_table (
+                    in_integers  IN  VARCHAR2,
+                    in_pattern   IN  VARCHAR2 DEFAULT '[0-9]+'
+                ) RETURN sys.ora_mining_number_nt
+                    DETERMINISTIC
+                    ACCESSIBLE BY ( PACKAGE the_api.math, PACKAGE the_api.test_math )
+                IS
+            
+                    l_result  sys.ora_mining_number_nt := sys.ora_mining_number_nt();
+                    l_pos     INTEGER := 1;
+                    l_int     INTEGER;
+                BEGIN
+                    << integer_tokens >> LOOP
+                        l_int := to_number(regexp_substr(in_integers, in_pattern, 1, l_pos));
+                        EXIT integer_tokens WHEN l_int IS NULL;
+                        l_result.extend;
+                        l_result(l_pos) := l_int;
+                        l_pos := l_pos + 1;
+                    END LOOP integer_tokens;
+            
+                    RETURN l_result;
+                END to_int_table;
+            
+            END math;
+            /
+        '''.toString.trim
+        val actualPackageBody = getFormattedContent("package_body.pkb")
+        Assert.assertEquals(expectedPackageBody, actualPackageBody)
+ 
+        // query.sql
+        val expectedQuery = '''
+            SELECT
+                d.department_name,
+                v.employee_id,
+                v.last_name
+            FROM
+                departments  d CROSS APPLY (
+                    SELECT
+                        *
+                    FROM
+                        employees e
+                    WHERE
+                        e.department_id = d.department_id
+                )            v
+            WHERE
+                d.department_name IN ( 'Marketing', 'Operations', 'Public Relations' )
+            ORDER BY
+                d.department_name,
+                v.employee_id;
+        '''.toString.trim
+        val actualQuery = getFormattedContent("query.sql")
+        Assert.assertEquals(expectedQuery, actualQuery)
+    }
+
 }

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/WrongArgumentTest.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/WrongArgumentTest.xtend
@@ -8,7 +8,7 @@ class WrongArgumentTest extends AbstractSqlclTest {
     @Test
     def void no_arguments() {
         val expected = '''
-
+            
             format.js for SQLcl 20.2
             Copyright 2020 by Philipp Salvisberg (philipp.salvisberg@trivadis.com)
             
@@ -22,8 +22,11 @@ class WrongArgumentTest extends AbstractSqlclTest {
             options:
               ext=<ext>      comma separated list of file extensions to process, e.g. ext=sql,pks,pkb
               xml=<file>     path to the file containing the xml file for advanced format settings
+                             xml=default used default advanced settings included in sqlcl
+                             xml=embedded used advanced settings defined in format.js
               arbori=<file>  path to the file containing the Arbori program for custom format settings
-
+                             arbori=default uses default Arbori program included in sqlcl
+            
         '''
         val actual = runScript()
         Assert.assertEquals(expected, actual)

--- a/sqldev/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/WrongArgumentTest.xtend
+++ b/sqldev/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/WrongArgumentTest.xtend
@@ -21,6 +21,7 @@ class WrongArgumentTest extends AbstractSqlclTest {
             
             options:
               ext=<ext>      comma separated list of file extensions to process, e.g. ext=sql,pks,pkb
+              xml=<file>     path to the file containing the xml file for advanced format settings
               arbori=<file>  path to the file containing the Arbori program for custom format settings
 
         '''

--- a/sqldev/src/test/resources/advanced_format.xml
+++ b/sqldev/src/test/resources/advanced_format.xml
@@ -1,0 +1,32 @@
+<options>
+    <adjustCaseOnly>false</adjustCaseOnly>
+    <alignTabColAliases>false</alignTabColAliases>
+    <breakOnSubqueries>true</breakOnSubqueries>
+    <alignEquality>false</alignEquality>
+    <singleLineComments>oracle.dbtools.app.Format.InlineComments.CommentsUnchanged</singleLineComments>
+    <breakAnsiiJoin>true</breakAnsiiJoin>
+    <maxCharLineSize>120</maxCharLineSize>
+    <alignAssignments>true</alignAssignments>
+    <breaksProcArgs>true</breaksProcArgs>
+    <alignRight>true</alignRight>
+    <breaksComma>oracle.dbtools.app.Format.Breaks.Before</breaksComma>
+    <breaksAroundLogicalConjunctions>oracle.dbtools.app.Format.Breaks.Before</breaksAroundLogicalConjunctions>
+    <alignNamedArgs>true</alignNamedArgs>
+    <formatProgramURL>default</formatProgramURL>
+    <formatThreshold>1</formatThreshold>
+    <spaceAroundOperators>true</spaceAroundOperators>
+    <useTab>false</useTab>
+    <idCase>oracle.dbtools.app.Format.Case.NoCaseChange</idCase>
+    <extraLinesAfterSignificantStatements>oracle.dbtools.app.Format.BreaksX2.X1</extraLinesAfterSignificantStatements>
+    <breaksConcat>oracle.dbtools.app.Format.Breaks.Before</breaksConcat>
+    <spaceAroundBrackets>oracle.dbtools.app.Format.Space.Default</spaceAroundBrackets>
+    <flowControl>oracle.dbtools.app.Format.FlowControl.IndentedActions</flowControl>
+    <commasPerLine>1</commasPerLine>
+    <forceLinebreaksBeforeComment>false</forceLinebreaksBeforeComment>
+    <alignTypeDecl>true</alignTypeDecl>
+    <breakParenCondition>true</breakParenCondition>
+    <identSpaces>3</identSpaces>
+    <breaksAfterSelect>false</breaksAfterSelect>
+    <spaceAfterCommas>true</spaceAfterCommas>
+    <kwCase>oracle.dbtools.app.Format.Case.UPPER</kwCase>
+</options>


### PR DESCRIPTION
Closes #41 - load advanced settings using 
xml=file (from file)
xml=default (default settings of formatter in sqlcl)
xml=embedded (settings configured in `format.js`