### PR TITLE
Feature/issue 72 keep breaks

### DIFF
--- a/settings/sql_developer/trivadis_advanced_format.xml
+++ b/settings/sql_developer/trivadis_advanced_format.xml
@@ -17,7 +17,7 @@
     <spaceAroundOperators>true</spaceAroundOperators>
     <useTab>false</useTab>
     <idCase>oracle.dbtools.app.Format.Case.NoCaseChange</idCase>
-    <extraLinesAfterSignificantStatements>oracle.dbtools.app.Format.BreaksX2.X1</extraLinesAfterSignificantStatements>
+    <extraLinesAfterSignificantStatements>oracle.dbtools.app.Format.BreaksX2.Keep</extraLinesAfterSignificantStatements>
     <breaksConcat>oracle.dbtools.app.Format.Breaks.Before</breaksConcat>
     <spaceAroundBrackets>oracle.dbtools.app.Format.Space.Default</spaceAroundBrackets>
     <flowControl>oracle.dbtools.app.Format.FlowControl.IndentedActions</flowControl>

--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -72,7 +72,7 @@ var configure = function (formatter, xmlPath, arboriPath) {
         formatter.options.put(formatter.breakOnSubqueries, true);                                       // default: true
         formatter.options.put(formatter.maxCharLineSize, 120);                                          // default: 128
         formatter.options.put(formatter.forceLinebreaksBeforeComment, false);                           // default: false
-        formatter.options.put(formatter.extraLinesAfterSignificantStatements, Format.BreaksX2.X1);      // default: Format.BreaksX2.X2
+        formatter.options.put(formatter.extraLinesAfterSignificantStatements, Format.BreaksX2.Keep);    // default: Format.BreaksX2.X2
         formatter.options.put(formatter.breaksAfterSelect, false);                                      // default: true
         formatter.options.put(formatter.flowControl, Format.FlowControl.IndentedActions);               // default: Format.FlowControl.IndentedActions
         // White Space

--- a/tests/src/test/java/com/trivadis/plsql/formatter/settings/examples/Oracle.xtend
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/settings/examples/Oracle.xtend
@@ -39,8 +39,8 @@ class Oracle extends ConfiguredTestFormatter {
                         dbms_output.put_line('sal_raise := 0');
                   END CASE;
                   SELECT CASE "1"
-                            WHEN 1 THEN
-                               'XX'
+                           WHEN 1 THEN
+                              'XX'
                          END
                     INTO new_empno
                     FROM emp,

--- a/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.xtend
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.xtend
@@ -23,9 +23,9 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
         Assert.assertEquals(expected, actual)
         
         // package_body.pkb
+        // Breaks.Keep leads to no breaks after significant statements, that's correct
         val expectedPackageBody = '''
-            CREATE OR REPLACE PACKAGE BODY the_api.math AS
-               FUNCTION to_int_table (
+            CREATE OR REPLACE PACKAGE BODY the_api.math AS FUNCTION to_int_table (
                   in_integers  IN  VARCHAR2,
                   in_pattern   IN  VARCHAR2 DEFAULT '[0-9]+'
                ) RETURN sys.ora_mining_number_nt
@@ -43,10 +43,8 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
                      l_result.extend;
                      l_result(l_pos)     := l_int;
                      l_pos               := l_pos + 1;
-                  END LOOP integer_tokens;
-                  RETURN l_result;
-               END to_int_table;
-            END math;
+                  END LOOP integer_tokens;RETURN l_result;
+               END to_int_table;END math;
             /
         '''.toString.trim
         val actualPackageBody = getFormattedContent("package_body.pkb")
@@ -84,9 +82,9 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
         Assert.assertTrue(actual.contains("file 1 of 1"))
         
         // package_body.pkb
+        // Breaks.Keep leads to no breaks after significant statements, that's correct
         val expectedPackageBody = '''
-            CREATE OR REPLACE PACKAGE BODY the_api.math AS
-               FUNCTION to_int_table (
+            CREATE OR REPLACE PACKAGE BODY the_api.math AS FUNCTION to_int_table (
                   in_integers  IN  VARCHAR2,
                   in_pattern   IN  VARCHAR2 DEFAULT '[0-9]+'
                ) RETURN sys.ora_mining_number_nt
@@ -104,10 +102,8 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
                      l_result.extend;
                      l_result(l_pos)     := l_int;
                      l_pos               := l_pos + 1;
-                  END LOOP integer_tokens;
-                  RETURN l_result;
-               END to_int_table;
-            END math;
+                  END LOOP integer_tokens;RETURN l_result;
+               END to_int_table;END math;
             /
         '''.toString.trim
         val actualPackageBody = getFormattedContent("package_body.pkb")
@@ -121,16 +117,15 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
         Assert.assertTrue(actual.contains("query.sql"))
 
         // package_body.pkb
+        // Breaks.Keep leads to no breaks after significant statements, that's correct
         val expectedPackageBody = '''
-            CREATE OR REPLACE PACKAGE BODY the_api.math AS
-               FUNCTION to_int_table (
+            CREATE OR REPLACE PACKAGE BODY the_api.math AS FUNCTION to_int_table (
                   in_integers  IN  VARCHAR2,
                   in_pattern   IN  VARCHAR2 DEFAULT '[0-9]+'
                ) RETURN sys.ora_mining_number_nt
                   DETERMINISTIC
                   ACCESSIBLE BY ( PACKAGE the_api.math, PACKAGE the_api.test_math )
-               IS
-                  l_result  sys.ora_mining_number_nt := sys.ora_mining_number_nt();
+               IS l_result  sys.ora_mining_number_nt := sys.ora_mining_number_nt();
                   l_pos     INTEGER := 1;
                   l_int     INTEGER;
                BEGIN
@@ -145,10 +140,8 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
                      l_result.extend;
                      l_result(l_pos)     := l_int;
                      l_pos               := l_pos + 1;
-                  END LOOP integer_tokens;
-                  RETURN l_result;
-               END to_int_table;
-            END math;
+                  END LOOP integer_tokens;RETURN l_result;
+               END to_int_table;END math;
             /
         '''.toString.trim
         val actualPackageBody = getFormattedContent("package_body.pkb")
@@ -178,20 +171,18 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
         // run
         val actual = run(runType, tempDir.toString(), "arbori=default")
         Assert.assertTrue(actual.contains("package_body.pkb"))
-        Assert.assertTrue(actual.contains("query.sql"))
-        
+        Assert.assertTrue(actual.contains("query.sql")) 
 
         // package_body.pkb
+        // Breaks.Keep leads to no breaks after significant statements, that's correct
         val expectedPackageBody = '''
-            CREATE OR REPLACE PACKAGE BODY the_api.math AS
-               FUNCTION to_int_table (
+            CREATE OR REPLACE PACKAGE BODY the_api.math AS FUNCTION to_int_table (
                   in_integers  IN  VARCHAR2,
                   in_pattern   IN  VARCHAR2 DEFAULT '[0-9]+'
                ) RETURN sys.ora_mining_number_nt
                   DETERMINISTIC
                   ACCESSIBLE BY ( PACKAGE the_api.math, PACKAGE the_api.test_math )
-               IS
-                  l_result  sys.ora_mining_number_nt := sys.ora_mining_number_nt();
+               IS l_result  sys.ora_mining_number_nt := sys.ora_mining_number_nt();
                   l_pos     INTEGER := 1;
                   l_int     INTEGER;
                BEGIN
@@ -206,10 +197,8 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
                      l_result.extend;
                      l_result(l_pos)     := l_int;
                      l_pos               := l_pos + 1;
-                  END LOOP integer_tokens;
-                  RETURN l_result;
-               END to_int_table;
-            END math;
+                  END LOOP integer_tokens;RETURN l_result;
+               END to_int_table;END math;
             /
         '''.toString.trim
         val actualPackageBody = getFormattedContent("package_body.pkb")
@@ -242,6 +231,7 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
         Assert.assertTrue(actual.contains("query.sql"))
 
         // package_body.pkb
+        // Breaks.X1 leads to breaks after significant statements, that's better than the default Breaks.Keep in this case
         val expectedPackageBody = '''
             CREATE OR REPLACE PACKAGE BODY the_api.math AS
                FUNCTION to_int_table (
@@ -364,16 +354,15 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
         Assert.assertTrue(actual.contains("query.sql"))
 
         // package_body.pkb
+        // Breaks.Keep leads to no breaks after significant statements, that's correct
         val expectedPackageBody = '''
-            CREATE OR REPLACE PACKAGE BODY the_api.math AS
-               FUNCTION to_int_table (
+            CREATE OR REPLACE PACKAGE BODY the_api.math AS FUNCTION to_int_table (
                   in_integers  IN  VARCHAR2,
                   in_pattern   IN  VARCHAR2 DEFAULT '[0-9]+'
                ) RETURN sys.ora_mining_number_nt
                   DETERMINISTIC
                   ACCESSIBLE BY ( PACKAGE the_api.math, PACKAGE the_api.test_math )
-               IS
-                  l_result  sys.ora_mining_number_nt := sys.ora_mining_number_nt();
+               IS l_result  sys.ora_mining_number_nt := sys.ora_mining_number_nt();
                   l_pos     INTEGER := 1;
                   l_int     INTEGER;
                BEGIN
@@ -388,10 +377,8 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
                      l_result.extend;
                      l_result(l_pos)     := l_int;
                      l_pos               := l_pos + 1;
-                  END LOOP integer_tokens;
-                  RETURN l_result;
-               END to_int_table;
-            END math;
+                  END LOOP integer_tokens;RETURN l_result;
+               END to_int_table;END math;
             /
         '''.toString.trim
         val actualPackageBody = getFormattedContent("package_body.pkb")
@@ -423,6 +410,7 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
         Assert.assertTrue (actualConsole.contains('''Formatting file 1 of 1: «tempDir.toString()»«File.separator»markdown.md... done.'''))
         
         // markdown.md
+        // Breaks.Keep leads to no breaks after significant statements, that's correct
         val actualMarkdown = getFormattedContent("markdown.md").trim
         val expectedMarkdown = '''
             # Titel
@@ -436,8 +424,7 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
             Here's the content of package_body.pkb
             
             ```sql
-            CREATE OR REPLACE PACKAGE BODY the_api.math AS
-               FUNCTION to_int_table (
+            CREATE OR REPLACE PACKAGE BODY the_api.math AS FUNCTION to_int_table (
                   in_integers  IN  VARCHAR2,
                   in_pattern   IN  VARCHAR2 DEFAULT '[0-9]+'
                ) RETURN sys.ora_mining_number_nt
@@ -455,10 +442,8 @@ abstract class AbstractFormatTest extends AbstractSqlclTest {
                      l_result.extend;
                      l_result(l_pos)     := l_int;
                      l_pos               := l_pos + 1;
-                  END LOOP integer_tokens;
-                  RETURN l_result;
-               END to_int_table;
-            END math;
+                  END LOOP integer_tokens;RETURN l_result;
+               END to_int_table;END math;
             /
             ```
             


### PR DESCRIPTION
closes #72 - Change default for extraLinesAfterSignificantStatements to BreaksX2.Keep
- New default Breaks.Keep instead of Breaks.X1 for extraLinesAfterSignificantStatements.
- For code without new lines after significant statements, no newlines are added. This is considered correct. The new lines are kept. In this case zero new lines. In such cases Breaks.X1 or Breaks.X2 produce the better formatting result. However, for typical use cases where sometimes a newline is added to improve readability, the result is better since this new line is kept.
- Please not that multiple consecutive empty lines are reduced to one empty line. This is an intended behaviour. 