### PR TITLE
Feature #33 - split arguments based on line size

### DIFF
--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -519,14 +519,59 @@ indentedNodes2: indentedNodes1
  * Add line breaks if argument and expression lists have more than 4 argurments.
  * Must run at this position where all other split and indentations are handled.
  * Calling indentedNodes1 and indentedNodes2 manually due to Arbori query limitations.
- * Solves issues #19 
+ * Solves issues #19, #33 
  */
+
+longArgList: runOnce -> {
+  var HashSet = Java.type('java.util.HashSet');
+  var longArgListSet = new HashSet();
+  var longExprListSet = new HashSet();
+  /* 80% of maxCharLineSize, to be on the save side and accept unnecessary line breaks to control outcome */
+  var maxLineSize = struct.options.get("maxCharLineSize") * .8;
+  var alreadyIndentedSet = new HashSet();
+  
+  function addToLongSet(set, nodeName) {
+    var node = tuple.get(nodeName);
+    var size = 0;
+    for(i = node.from; i < node.to; i++) {
+      // content plus 1 whitespace
+      size += (target.getSrc()[i].content.length) + 1;
+  	}
+  	if (size > maxLineSize) {
+  	  logger.fine(struct.getClass(), "addToLongSet (added): " + node);
+  	  set.add(node.interval());
+  	}
+  }
+
+  function isLongArgList(nodeName) {
+    var nodeInterval = tuple.get(nodeName).interval();
+    return longArgListSet.contains(nodeInterval);
+  }
+
+  function isLongExprList(nodeName) {
+    var nodeInterval = tuple.get(nodeName).interval();
+    return longExprListSet.contains(nodeInterval);
+  }
+  
+  function isAlreadyIndented(nodeName) {
+    var nodeInterval = tuple.get(nodeName).interval();
+    return alreadyIndentedSet.contains(nodeInterval);  	
+  }
+
+}
+
+addLongArgList: 
+  [parent) paren_expr_list 
+  -> {
+    logger.fine(struct.getClass(), "addLongArgList (found): " + tuple.get('parent'));
+    addToLongSet(longArgListSet, 'parent');
+  }
 
 allArgList:
   [parent) paren_expr_list
 ;
 
-splittableArgList:
+splittableArgList1:
   [parent) paren_expr_list 
     & [arg1) arg_list 
     & arg1^ = parent
@@ -538,11 +583,40 @@ splittableArgList:
     & arg4^ = arg3
 ;
 
+splittableArgList2:
+    [parent) paren_expr_list 
+  & .isLongArgList('parent')
+;
+
+splittableArgList:
+    splittableArgList1
+  | splittableArgList2 
+;
+
+addLongExprList: 
+  [parent) "(x,y,z)"
+  -> {
+    logger.fine(struct.getClass(), "addLongExprList (found): " + tuple.get('parent'));
+    addToLongSet(longExprListSet, 'parent');
+  }
+  
+addAlreadyIndented:
+  .breaksAssocArgs & (
+      [node) assoc_arg & [node^) paren_expr_list & [node+1) arg_list
+    | [node) arg_list & [node^) paren_expr_list & [node-1) assoc_arg
+    | [node) ',' & [node^) arg_list & [node+1) assoc_arg
+  )
+  -> {
+    var node = tuple.get('node');
+    logger.fine(struct.getClass(), "addAlreadyIndented: " + node);
+    alreadyIndentedSet.add(node.interval());
+  }
+
 allExprList:
   [parent) "(x,y,z)"
 ;
 
-splittableExprList:
+splittableExprList1:
   [parent) "(x,y,z)" 
     & [arg1) "expr_list" 
     & parent < arg1
@@ -556,33 +630,71 @@ splittableExprList:
     & arg5^ = arg4
 ;
 
+splittableExprList2:
+    [parent) "(x,y,z)" 
+  & .isLongExprList('parent')
+;
+
+splittableExprList:
+    splittableExprList1
+  | splittableExprList2
+;
+
+indentArgListParent:
+  .breaksProcArgs
+    & [argList) paren_expr_list
+    & [argList^^) assignment_stmt
+    & [node) name
+    & node = argList^
+    & splittableArgList.parent = argList
+  -> {
+    logger.fine(struct.getClass(), "indentArgListParent: " + tuple.get('node'));
+    struct.indentedNodes1(target, tuple);
+    struct.indentedNodes2(target, tuple);
+  }
+
 splitArg:
-  .breaksProcArgs 
+  .breaksProcArgs
     & [node) arg 
-    & ![node) assoc_arg 
     & allArgList.parent < node
     & splittableArgList.parent < node
   -> {
-    // filter via JavaScript since "allArgList.parent = splittableArgList.parent" does not work as Arbori condition
+    // filter via JavaScript
     var all = tuple.get("allArgList.parent");
     var splittable = tuple.get("splittableArgList.parent");
-    if (all == splittable) {
+    logger.fine(struct.getClass(), "splitArg (found): " + tuple.get('node'));
+    if (all == splittable && !isAlreadyIndented('node')) {
+      logger.fine(struct.getClass(), "splitArg (splitted): " + tuple.get('node'));
       struct.indentedNodes1(target, tuple);
       struct.indentedNodes2(target, tuple);
     }
   }
 
+indentAssocArgs:
+  .breaksProcArgs
+    & ([node) assoc_arg | [node) ')' & [node^) paren_expr_list)
+    & paren_expr_list = node 
+    & splittableExprList.parent < node
+  -> {
+    logger.fine(struct.getClass(), "indentExprList: " + tuple.get('node'));
+    struct.indentedNodes1(target, tuple);
+    struct.indentedNodes2(target, tuple);
+  }
+
 splitExpr:
   .breaksProcArgs 
     & [node) expr 
-    & ![node) assoc_arg 
+    & ![node^) assoc_arg 
+    & ![node^) compound_expression
     & allExprList.parent < node
     & splittableExprList.parent < node
   -> {
-    // filter via JavaScript since "allExprList.parent.parent = splittableExprList.parent" does not work as Arbori condition
+    // filter via JavaScript
     var all = tuple.get("allExprList.parent");
     var splittable = tuple.get("splittableExprList.parent");
-    if (all == splittable) {
+    logger.fine(struct.getClass(), "splitExpr (found): " + tuple.get('node'));
+    if (all == splittable && !isAlreadyIndented('node')) {
+      logger.fine(struct.getClass(), "splitExpr (splitted): " + tuple.get('node'));
       struct.indentedNodes1(target, tuple);
       struct.indentedNodes2(target, tuple);
     }
@@ -860,7 +972,7 @@ _extraBrkAfter:
 **/
 commasInProc: [node) ',' 
        & procedureCall < node 
-       & (   [procedureCall) function_call 
+       & (   [procedureCall) function_call
            | [procedureCall) function &  (!.breaks4XML | ![procedureCall) XML_function  /*implication .breaks4XML -> ![procedureCall) XML_function */ )
            | [procedureCall) procedure_call 
            | [procedureCall) in_condition & ![node+1) select_term -- salvisberg, exclude select_term (#76)
@@ -1261,6 +1373,16 @@ pairwiseAlignmentXmlTableColumn: -- salvisberg, added, issue #57
     & ancestor<predecessor & ancestor<node & ancestor=predecessor^
 ;
 
+pairwiseAlignementAssocArg:
+  :breaksAfterComma
+  & [node) assoc_arg
+  & [node-1) ','
+  & [ancestor) paren_expr_list
+  & ancestor < node
+  & [predecessor) assoc_arg
+  & predecessor^ = ancestor
+;
+
 pairwiseAlignments: 
   --  pairwiseAlignments00            -- salvisberg, disabled (#76)
   --| pairwiseAlignments0             -- salvisberg, disabled (#76)
@@ -1282,7 +1404,8 @@ pairwiseAlignments:
   --| pairwiseAlignments12            -- salvisberg, disabled (#76)
   | pairwiseAlignmentXmlTable         -- salvisberg, added, issue #57
   | pairwiseAlignmentXmlTableColumn   -- salvisberg, added, issue #57
-->
+  | pairwiseAlignementAssocArg        -- salvisberg, added, issue #33
+-> 
 ;
 
 

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -221,6 +221,182 @@ maxOneEmptyLine: runOnce -> {
 }
 
 /**
+ * salvisberg: start section "split arguments"
+ *
+ * Add line breaks if argument and expression lists have more than 4 argurments.
+ * Must run at this position where all other split and indentations are handled.
+ * Solves issues #19, #33 
+ */
+
+longArgList: runOnce -> {
+  var HashSet = Java.type('java.util.HashSet');
+  var longSet = new HashSet();
+  var splittedNodeSet = new HashSet();
+  /* 80% of maxCharLineSize, to be on the save side and accept unnecessary line breaks to control outcome */
+  var maxLineSize = struct.options.get("maxCharLineSize") * .8;
+  
+  function addToLongSet(nodeName) {
+    var node = tuple.get(nodeName);
+    var size = 0;
+    for(i = node.from; i < node.to; i++) {
+      // content plus 1 whitespace
+      size += (target.getSrc()[i].content.length) + 1;
+  	}
+  	if (size > maxLineSize) {
+  	  logger.fine(struct.getClass(), "addToLongSet (added): " + node);
+  	  longSet.add(node.interval());
+  	}
+  }
+
+  function isLong(nodeName) {
+    var nodeInterval = tuple.get(nodeName).interval();
+    return longSet.contains(nodeInterval);
+  }
+  
+  function isSplitted(nodeName) {
+    var nodeInterval = tuple.get(nodeName).interval();
+    return splittedNodeSet.contains(nodeInterval);
+  }
+}
+
+addLongArgList: 
+  [parent) paren_expr_list 
+  -> {
+    logger.fine(struct.getClass(), "addLongArgList (found): " + tuple.get('parent'));
+    addToLongSet('parent');
+  }
+
+allArgList:
+  [parent) paren_expr_list
+;
+
+splittableArgList1:
+  [parent) paren_expr_list 
+    & [arg1) arg_list 
+    & arg1^ = parent
+    & [arg2) arg_list 
+    & arg2^ = arg1
+    & [arg3) arg_list 
+    & arg3^ = arg2
+    & [arg4) arg_list 
+    & arg4^ = arg3
+;
+
+splittableArgList2:
+    [parent) paren_expr_list 
+  & .isLong('parent')
+;
+
+splittableArgList:
+    splittableArgList1
+  | splittableArgList2 
+;
+
+addLongExprList: 
+  [parent) "(x,y,z)"
+  -> {
+    logger.fine(struct.getClass(), "addLongExprList (found): " + tuple.get('parent'));
+    addToLongSet('parent');
+  }
+
+allExprList:
+  [parent) "(x,y,z)"
+;
+
+splittableExprList1:
+  [parent) "(x,y,z)" 
+    & [arg1) "expr_list" 
+    & parent < arg1
+    & [arg2) "expr_list" 
+    & arg2^ = arg1
+    & [arg3) "expr_list" 
+    & arg3^ = arg2
+    & [arg4) "expr_list" 
+    & arg4^ = arg3
+    & [arg5) "expr_list" 
+    & arg5^ = arg4
+;
+
+splittableExprList2:
+    [parent) "(x,y,z)" 
+  & .isLong('parent')
+;
+
+splittableExprList:
+    splittableExprList1
+  | splittableExprList2
+;
+
+indentArgListParent:
+  .breaksProcArgs
+    & [argList) paren_expr_list
+    & [argList^^) assignment_stmt
+    & [node) name
+    & node = argList^
+    & splittableArgList.parent = argList
+  -> {
+    logger.fine(struct.getClass(), "indentArgListParent: " + tuple.get('node'));
+    splittedNodeSet.add(tuple.get('node').interval());
+  }
+
+splitArg:
+  .breaksProcArgs
+    & [node) arg 
+    & allArgList.parent < node
+    & splittableArgList.parent < node
+  -> {
+    // filter via JavaScript
+    var all = tuple.get("allArgList.parent");
+    var splittable = tuple.get("splittableArgList.parent");
+    logger.fine(struct.getClass(), "splitArg (found): " + tuple.get('node'));
+    if (all == splittable) {
+      logger.fine(struct.getClass(), "splitArg (splitted): " + tuple.get('node'));
+      splittedNodeSet.add(tuple.get('node').interval());
+    }
+  }
+  
+splitExpr:
+  .breaksProcArgs 
+    & [node) expr 
+    & ![node^) assoc_arg 
+    & ![node^) compound_expression
+    & allExprList.parent < node
+    & splittableExprList.parent < node
+  -> {
+    // filter via JavaScript
+    var all = tuple.get("allExprList.parent");
+    var splittable = tuple.get("splittableExprList.parent");
+    logger.fine(struct.getClass(), "splitExpr (found): " + tuple.get('node'));
+    if (all == splittable) {
+      logger.fine(struct.getClass(), "splitExpr (splitted): " + tuple.get('node'));
+      splittedNodeSet.add(tuple.get('node').interval());
+    }
+  }
+  
+indentFirstAssocArgs:
+  .breaksProcArgs
+    & [node) assoc_arg 
+    & [node^) paren_expr_list
+    & splittableArgList.parent = node^    
+  -> {
+    logger.fine(struct.getClass(), "indentFirstAssocArgs: " + tuple.get('node'));
+    splittedNodeSet.add(tuple.get('node').interval());
+  }
+
+splittedNodes: 
+  (
+     [node) expr
+   | [node) arg
+   | [node) assoc_arg
+   | [node) name
+  ) & .isSplitted('node')
+;
+
+/**
+ * salvisberg: stop section "split arguments"
+ */
+
+/**
  * simpleIndentConditions  
  * Parse nodes to be indented with simple conditions, typically parse node payload, e.g.
    [node) select_term                               --<-- all parse nodes with "select_term" payload
@@ -501,7 +677,10 @@ ancestor < node & ![node^) "(x,y,z)" & [node) column  & (
 );
 
 
-indentedNodes1: simpleIndentConditions | closestAncestorDescendent
+indentedNodes1: 
+    simpleIndentConditions 
+  | closestAncestorDescendent 
+  | splittedNodes               -- salvisberg: added to solve issue #33
 ->
 ;
 
@@ -512,197 +691,6 @@ indentedNodes1: simpleIndentConditions | closestAncestorDescendent
 indentedNodes2: indentedNodes1
 ->
 ;
-
-/**
- * salvisberg: start section "split arguments"
- *
- * Add line breaks if argument and expression lists have more than 4 argurments.
- * Must run at this position where all other split and indentations are handled.
- * Calling indentedNodes1 and indentedNodes2 manually due to Arbori query limitations.
- * Solves issues #19, #33 
- */
-
-longArgList: runOnce -> {
-  var HashSet = Java.type('java.util.HashSet');
-  var longArgListSet = new HashSet();
-  var longExprListSet = new HashSet();
-  /* 80% of maxCharLineSize, to be on the save side and accept unnecessary line breaks to control outcome */
-  var maxLineSize = struct.options.get("maxCharLineSize") * .8;
-  var alreadyIndentedSet = new HashSet();
-  
-  function addToLongSet(set, nodeName) {
-    var node = tuple.get(nodeName);
-    var size = 0;
-    for(i = node.from; i < node.to; i++) {
-      // content plus 1 whitespace
-      size += (target.getSrc()[i].content.length) + 1;
-  	}
-  	if (size > maxLineSize) {
-  	  logger.fine(struct.getClass(), "addToLongSet (added): " + node);
-  	  set.add(node.interval());
-  	}
-  }
-
-  function isLongArgList(nodeName) {
-    var nodeInterval = tuple.get(nodeName).interval();
-    return longArgListSet.contains(nodeInterval);
-  }
-
-  function isLongExprList(nodeName) {
-    var nodeInterval = tuple.get(nodeName).interval();
-    return longExprListSet.contains(nodeInterval);
-  }
-  
-  function isAlreadyIndented(nodeName) {
-    var nodeInterval = tuple.get(nodeName).interval();
-    return alreadyIndentedSet.contains(nodeInterval);  	
-  }
-
-}
-
-addLongArgList: 
-  [parent) paren_expr_list 
-  -> {
-    logger.fine(struct.getClass(), "addLongArgList (found): " + tuple.get('parent'));
-    addToLongSet(longArgListSet, 'parent');
-  }
-
-allArgList:
-  [parent) paren_expr_list
-;
-
-splittableArgList1:
-  [parent) paren_expr_list 
-    & [arg1) arg_list 
-    & arg1^ = parent
-    & [arg2) arg_list 
-    & arg2^ = arg1
-    & [arg3) arg_list 
-    & arg3^ = arg2
-    & [arg4) arg_list 
-    & arg4^ = arg3
-;
-
-splittableArgList2:
-    [parent) paren_expr_list 
-  & .isLongArgList('parent')
-;
-
-splittableArgList:
-    splittableArgList1
-  | splittableArgList2 
-;
-
-addLongExprList: 
-  [parent) "(x,y,z)"
-  -> {
-    logger.fine(struct.getClass(), "addLongExprList (found): " + tuple.get('parent'));
-    addToLongSet(longExprListSet, 'parent');
-  }
-  
-addAlreadyIndented:
-  .breaksAssocArgs & (
-      [node) assoc_arg & [node^) paren_expr_list & [node+1) arg_list
-    | [node) arg_list & [node^) paren_expr_list & [node-1) assoc_arg
-    | [node) ',' & [node^) arg_list & [node+1) assoc_arg
-  )
-  -> {
-    var node = tuple.get('node');
-    logger.fine(struct.getClass(), "addAlreadyIndented: " + node);
-    alreadyIndentedSet.add(node.interval());
-  }
-
-allExprList:
-  [parent) "(x,y,z)"
-;
-
-splittableExprList1:
-  [parent) "(x,y,z)" 
-    & [arg1) "expr_list" 
-    & parent < arg1
-    & [arg2) "expr_list" 
-    & arg2^ = arg1
-    & [arg3) "expr_list" 
-    & arg3^ = arg2
-    & [arg4) "expr_list" 
-    & arg4^ = arg3
-    & [arg5) "expr_list" 
-    & arg5^ = arg4
-;
-
-splittableExprList2:
-    [parent) "(x,y,z)" 
-  & .isLongExprList('parent')
-;
-
-splittableExprList:
-    splittableExprList1
-  | splittableExprList2
-;
-
-indentArgListParent:
-  .breaksProcArgs
-    & [argList) paren_expr_list
-    & [argList^^) assignment_stmt
-    & [node) name
-    & node = argList^
-    & splittableArgList.parent = argList
-  -> {
-    logger.fine(struct.getClass(), "indentArgListParent: " + tuple.get('node'));
-    struct.indentedNodes1(target, tuple);
-    struct.indentedNodes2(target, tuple);
-  }
-
-splitArg:
-  .breaksProcArgs
-    & [node) arg 
-    & allArgList.parent < node
-    & splittableArgList.parent < node
-  -> {
-    // filter via JavaScript
-    var all = tuple.get("allArgList.parent");
-    var splittable = tuple.get("splittableArgList.parent");
-    logger.fine(struct.getClass(), "splitArg (found): " + tuple.get('node'));
-    if (all == splittable && !isAlreadyIndented('node')) {
-      logger.fine(struct.getClass(), "splitArg (splitted): " + tuple.get('node'));
-      struct.indentedNodes1(target, tuple);
-      struct.indentedNodes2(target, tuple);
-    }
-  }
-
-indentAssocArgs:
-  .breaksProcArgs
-    & ([node) assoc_arg | [node) ')' & [node^) paren_expr_list)
-    & paren_expr_list = node 
-    & splittableExprList.parent < node
-  -> {
-    logger.fine(struct.getClass(), "indentExprList: " + tuple.get('node'));
-    struct.indentedNodes1(target, tuple);
-    struct.indentedNodes2(target, tuple);
-  }
-
-splitExpr:
-  .breaksProcArgs 
-    & [node) expr 
-    & ![node^) assoc_arg 
-    & ![node^) compound_expression
-    & allExprList.parent < node
-    & splittableExprList.parent < node
-  -> {
-    // filter via JavaScript
-    var all = tuple.get("allExprList.parent");
-    var splittable = tuple.get("splittableExprList.parent");
-    logger.fine(struct.getClass(), "splitExpr (found): " + tuple.get('node'));
-    if (all == splittable && !isAlreadyIndented('node')) {
-      logger.fine(struct.getClass(), "splitExpr (splitted): " + tuple.get('node'));
-      struct.indentedNodes1(target, tuple);
-      struct.indentedNodes2(target, tuple);
-    }
-  }
-
-/**
- * salvisberg: stop section "split arguments"
- */
 
 /**
  * The skipWhiteSpaceBeforeNode and skipWhiteSpaceBeforeNode are
@@ -1383,6 +1371,14 @@ pairwiseAlignementAssocArg:
   & predecessor^ = ancestor
 ;
 
+pairwiseAlignementCloseParen:
+  :breaksAfterComma
+  & [node) ')'
+  & [predecessor) expr
+  & [node^) paren_expr_list
+  & predecessor = node^^ 
+;
+
 pairwiseAlignments: 
   --  pairwiseAlignments00            -- salvisberg, disabled (#76)
   --| pairwiseAlignments0             -- salvisberg, disabled (#76)
@@ -1405,6 +1401,7 @@ pairwiseAlignments:
   | pairwiseAlignmentXmlTable         -- salvisberg, added, issue #57
   | pairwiseAlignmentXmlTableColumn   -- salvisberg, added, issue #57
   | pairwiseAlignementAssocArg        -- salvisberg, added, issue #33
+  | pairwiseAlignementCloseParen      -- salvisberg, added, issue #33
 -> 
 ;
 

--- a/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_33.xtend
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_33.xtend
@@ -1,0 +1,98 @@
+package com.trivadis.plsql.formatter.settings.tests
+
+import com.trivadis.plsql.formatter.settings.ConfiguredTestFormatter
+import oracle.dbtools.app.Format.Breaks
+import org.junit.Test
+
+class Issue_33 extends ConfiguredTestFormatter {
+    
+    @Test
+    def split_nested_args_commas_after() {
+        '''
+            CREATE PROCEDURE test_dedup_t_obj IS
+               l_input     t_obj_type;
+               l_actual    t_obj_type;
+               l_expected  t_obj_type;
+            BEGIN
+               l_input     :=
+                  t_obj_type(
+                     obj_type('MY_OWNER', 'VIEW', 'MY_VIEW'),
+                     obj_type('MY_OWNER', 'PACKAGE', 'MY_PACKAGE'),
+                     obj_type('MY_OWNER', 'VIEW', 'MY_VIEW')
+                  );
+               l_expected  :=
+                  t_obj_type(
+                     obj_type('MY_OWNER', 'PACKAGE', 'MY_PACKAGE'),
+                     obj_type('MY_OWNER', 'VIEW', 'MY_VIEW')
+                  );
+               l_actual    := type_util.dedup(l_input);
+               ut.expect(l_actual.count).to_equal(2);
+               ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected)).unordered;
+            END test_dedup_t_obj;
+        '''.formatAndAssert
+    }
+
+    @Test
+    def split_nested_args_commas_before() {
+        formatter.options.put(formatter.breaksComma, Breaks.Before);
+        '''
+            CREATE PROCEDURE test_dedup_t_obj IS
+               l_input     t_obj_type;
+               l_actual    t_obj_type;
+               l_expected  t_obj_type;
+            BEGIN
+               l_input     :=
+                  t_obj_type(
+                     obj_type('MY_OWNER', 'VIEW', 'MY_VIEW')
+                   , obj_type('MY_OWNER', 'PACKAGE', 'MY_PACKAGE')
+                   , obj_type('MY_OWNER', 'VIEW', 'MY_VIEW')
+                  );
+               l_expected  :=
+                  t_obj_type(
+                     obj_type('MY_OWNER', 'PACKAGE', 'MY_PACKAGE')
+                   , obj_type('MY_OWNER', 'VIEW', 'MY_VIEW')
+                  );
+               l_actual    := type_util.dedup(l_input);
+               ut.expect(l_actual.count).to_equal(2);
+               ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected)).unordered;
+            END test_dedup_t_obj;
+        '''.formatAndAssert
+    }
+    
+    @Test
+    def split_nested_functions() {
+    	'''
+    		SELECT some_quite_long_function_name(
+    		          another_long_function_name(
+    		             first_Column_id
+    		             || another_Column_id
+    		             || third_Column_id
+    		             || fourth_column_id
+    		             || fifth_column
+    		             || another_column,
+    		             'another parameter'
+    		          )
+    		       )
+    		  FROM t;
+    	'''.formatAndAssert
+   	}
+
+    @Test
+    def split_nested_functions_with_named_parameters() {
+    	'''
+    		SELECT some_quite_long_function_name(
+    		          another_long_function_name(
+    		             a  => first_Column_id
+    		                  || another_Column_id
+    		                  || third_Column_id
+    		                  || fourth_column_id
+    		                  || fifth_column
+    		                  || another_column,
+    		             b  => 'another parameter'
+    		          )
+    		       )
+    		  FROM t;
+    	'''.formatAndAssert
+   	}
+
+}

--- a/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_33.xtend
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_33.xtend
@@ -78,6 +78,27 @@ class Issue_33 extends ConfiguredTestFormatter {
    	}
 
     @Test
+    def split_nested_neste3d_functions() {
+    	'''
+    		SELECT some_quite_long_function_name(
+    		          another_long_function_name(
+    		             yet_another_long_function_name(
+    		                first_Column_id
+    		                || another_Column_id
+    		                || third_Column_id
+    		                || fourth_column_id
+    		                || fifth_column
+    		                || another_column,
+    		                'another parameter'
+    		             )
+    		          )
+    		       )
+    		  FROM t;
+    	'''.formatAndAssert
+   	}
+
+
+    @Test
     def split_nested_functions_with_named_parameters() {
     	'''
     		SELECT some_quite_long_function_name(
@@ -89,6 +110,45 @@ class Issue_33 extends ConfiguredTestFormatter {
     		                  || fifth_column
     		                  || another_column,
     		             b  => 'another parameter'
+    		          )
+    		       )
+    		  FROM t;
+    	'''.formatAndAssert
+   	}
+
+    @Test
+    def split_nested_functions_with_named_parameters_only() {
+    	'''
+    		SELECT some_quite_long_function_name(
+    		          a => another_long_function_name(
+    		                  b  => first_Column_id
+    		                       || another_Column_id
+    		                       || third_Column_id
+    		                       || fourth_column_id
+    		                       || fifth_column
+    		                       || another_column,
+    		                  c  => 'another parameter'
+    		               )
+    		       )
+    		  FROM t;
+    	'''.formatAndAssert
+   	}
+
+
+    @Test
+    def split_nested_nested_functions_with_named_parameters() {
+    	'''
+    		SELECT some_quite_long_function_name(
+    		          another_long_function_name(
+    		             yet_another_long_function_name(
+    		                a  => first_Column_id
+    		                     || another_Column_id
+    		                     || third_Column_id
+    		                     || fourth_column_id
+    		                     || fifth_column
+    		                     || another_column,
+    		                b  => 'another parameter'
+    		             )
     		          )
     		       )
     		  FROM t;


### PR DESCRIPTION
Closes #33 - Split argument list based on line size instead of number of arguments

- Splitting still occurs with 5 and more arguments
- However, when the total linesize is estimated to be longer than the configured max. line size then the splitting occurs independent of the number of arguments