### PR TITLE
Feature #83 - Keep line break after select hint

### DIFF
--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -1672,3 +1672,40 @@ dontFormatOffOnRanges: runOnce -> {
       }
     }
   }
+
+keepLineBreakAfterSelectHint: runOnce -> {
+    var Integer = Java.type('java.lang.Integer');
+    var LexerToken = Java.type('oracle.dbtools.parser.LexerToken'); 
+    var Token = Java.type('oracle.dbtools.parser.Token');
+    var tokens = LexerToken.parse(target.input, true);  // include hidden tokens not relevant to build a parse tree
+    var hiddenTokenCount = 0;
+    for (var i in tokens) {
+      var type = tokens[i].type;
+      if ((type == Token.LINE_COMMENT || type == Token.COMMENT) && tokens[i].content.length > 3) {
+        if (tokens[i].content.substring(2, 3) == "+") {
+          var prev = prevToken.content.toLowerCase();
+          if (prev == "select") {
+            prevToken = tokens[i];
+            var indent = struct.getNewline(new Integer(i-hiddenTokenCount-1));
+            if (indent == null) {
+              indent = "";
+            }
+            if (!indent.contains('\n')) {
+              indent = "\n" + indent;
+            }
+            for (var j=0; j<prev.length + 1; j++) {
+               indent += " ";
+            }
+            struct.putNewline(new Integer(i-hiddenTokenCount), indent);
+          }
+        }
+      }
+      if (type == Token.LINE_COMMENT || type == Token.COMMENT || type == Token.WS || 
+          type == Token.MACRO_SKIP || type == Token.SQLPLUSLINECONTINUE_SKIP)
+      {
+        hiddenTokenCount++;
+      } else {
+        prevToken = tokens[i];
+      }
+    }
+  }

--- a/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_83.xtend
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/Issue_83.xtend
@@ -1,0 +1,41 @@
+package com.trivadis.plsql.formatter.settings.tests
+
+import com.trivadis.plsql.formatter.settings.ConfiguredTestFormatter
+import org.junit.Test
+
+class Issue_83 extends ConfiguredTestFormatter {
+    
+    @Test
+    def select_single_column_with_hint() {
+        '''
+        	SELECT /*+ parallel(t, 2) */
+        	       a
+        	  FROM t;
+        '''.formatAndAssert
+    }
+
+    @Test
+    def select_two_columns_with_hint() {
+        '''
+        	SELECT /*+ parallel(t, 2) */
+        	       a,
+        	       b
+        	  FROM t;
+        '''.formatAndAssert
+    }
+
+    @Test
+    def two_selects_with_hints() {
+        '''
+        	SELECT /*+ parallel(t, 2) */
+        	       a
+        	  FROM t;
+
+        	SELECT /*+ parallel(t, 2) */
+        	       a
+        	  FROM t;
+        '''.formatAndAssert
+    }
+
+
+}


### PR DESCRIPTION
A line break after a select hint cannot be added since the serializer in SQL Developer removes it. However, if there is a new line after a comment/hint the new line will be preserved.