### PR TITLE
Bugfix/issue 103 graalvm test

### DIFF
--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -126,7 +126,8 @@ var readFile = function (file) {
 }
 
 var writeFile = function (file, content) {
-    javaFiles.write(file, content.getBytes());
+    var contentString = new javaString(content);
+    javaFiles.write(file, contentString.getBytes());
 }
 
 var existsDirectory = function(dir) {

--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -164,7 +164,7 @@ var printUsage = function (asCommand) {
 
 var getJsPath = function() {
     // use original args array at the time when the command was registered
-    return args[0].replaceAll("[^\\\\\\/]+(\\.js)?$", "");
+    return args[0].substring(0, args[0].lastIndexOf(javaFile.separator) + 1);
 }
 
 var getCdPath = function(path) {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -14,12 +14,23 @@
         <sqlcl.libdir>/usr/local/bin/sqlcl/lib</sqlcl.libdir>
     </properties>
     <dependencies>
-        <!-- Nashorn JavaScript engine required by the formatter and used for SQLcl -->
+        <!-- Nashorn JavaScript engine used by the formatter in Arbori programs -->
         <dependency>
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
             <version>15.2</version>
             <scope>test</scope>
+        </dependency>
+        <!-- GraalVM JavaScript engine used for testing format.js as if executed via SQLcl -->
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <version>21.0.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-scriptengine</artifactId>
+            <version>21.0.0.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
closes #113

It looks like the formatter still uses the Nashorn JS script engine.
The JS code in the Arbori program needs to be changed to make it compatible with the GraalVM JS engine in a future PR.
