### PR TITLE
Bugfix/issue 129 in out parameter

### DIFF
--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -1294,6 +1294,12 @@ a7_reverse_loop:
     & [node^) iterator_control
 ;
 
+a7_in_out_mode:
+      [node) 'OUT'
+    & [node-1) 'IN'
+    & [node^) mode
+;
+
 a7_one_space_before:
       a7_param_list
     | a7_as_alias
@@ -1308,6 +1314,7 @@ a7_one_space_before:
     | a7_type_definition
     | a7_when_cond
     | a7_reverse_loop
+    | a7_in_out_mode
 -> {
     var node = tuple.get("node");
     if (!hasCommentsBetweenPos(node.from, node.to)) {

--- a/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/issues/Issue_129_in_out_parameter.java
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/issues/Issue_129_in_out_parameter.java
@@ -1,0 +1,37 @@
+package com.trivadis.plsql.formatter.settings.tests.issues;
+
+import com.trivadis.plsql.formatter.settings.ConfiguredTestFormatter;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class Issue_129_in_out_parameter extends ConfiguredTestFormatter {
+
+    @Test
+    public void keep_in_out_mode_on_same_line() throws IOException {
+        var input = """
+                create or replace procedure dummy(
+                   a in
+                   out varchar2,
+                   b in
+                   out number
+                ) is
+                --BEFORE EACH ROW
+                begin
+                   null;
+                end;
+                """;
+        var expected = """
+                create or replace procedure dummy(
+                   a in out varchar2,
+                   b in out number
+                ) is
+                --BEFORE EACH ROW
+                begin
+                   null;
+                end;
+                """;
+        var actual = formatter.format(input);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Fixes #129 - enforce single space between `in out` parameter mode