### PR TITLE
Feature/issue 162 ignore

### DIFF
--- a/sqlcl/README.md
+++ b/sqlcl/README.md
@@ -44,6 +44,9 @@ options:
                   xml=embedded uses advanced settings defined in format.js
   arbori=<file>   path to the file containing the Arbori program for custom format settings
                   arbori=default uses default Arbori program included in sqlcl
+  ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined 
+                  per line. Each line represent a glob pattern. Empty lines and lines starting
+                  with a hash sign (#) are ignored. 
 ```
 
 ## Register Script `format.js` as SQLcl Command `tvdformat`

--- a/sqlcl/README.md
+++ b/sqlcl/README.md
@@ -110,7 +110,6 @@ With the `ignore` parameter you can define a file containing with file name patt
 ```
 # ignore all files under an "archive" subdirectory
 **/archive/**
-
               
 # ignore files containing "test" in the file name
 **/*test*

--- a/sqlcl/README.md
+++ b/sqlcl/README.md
@@ -76,7 +76,7 @@ options:
 
 It's very similar to `script format.js`. The advantage is, that you do not need to know where [`format.js`](format.js) is stored. You may pass relative paths for `rootPath` and `file`. The SQLcl `CD` command is honored.
 
-## Using a configuration file
+## Using a Configuration File
 
 In addition to `rootPath` and `*`, `format.js` can accept a JSON configuration file as the mandatory argument. Here's an example of using a configuration file:
 

--- a/sqlcl/README.md
+++ b/sqlcl/README.md
@@ -102,3 +102,20 @@ Here's an example configuration file:
   ]
 }
 ```
+
+## Using an Ignore File
+
+With the `ignore` parameter you can define a file containing with file name patterns to be ignored. Here's an example of an ignore file content:
+
+```
+# ignore all files under an "archive" subdirectory
+**/archive/**
+
+              
+# ignore files containing "test" in the file name
+**/*test*
+```
+
+[Glob](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-) patterns are applied on the complete file including the directory name. All patterns are supported except subpatterns (`{}`).
+
+Please note that defining file name patterns such as `*.?` will not work because they do not match the directory name of the file. Use `**/*.?` instead.

--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -337,13 +337,6 @@ var processAndValidateArgs = function (args) {
         }
         if (args[i].toLowerCase().startsWith("xml=")) {
             xmlPath = args[i].substring(4);
-            if (!"default".equals(xmlPath) && !"embedded".equals(xmlPath)) {
-                xmlPath = getCdPath(xmlPath);
-                if (!existsFile(xmlPath)) {
-                    ctx.write("file " + xmlPath + " does not exist.\n\n");
-                    return result(false);
-                }
-            }
             continue;
         }
         if (args[i].toLowerCase().startsWith("arbori=")) {
@@ -375,6 +368,14 @@ var processAndValidateArgs = function (args) {
         if (!existsFile(xmlPath)) {
             ctx.write('Warning: ' + xmlPath + ' not found, using "embedded" instead.\n\n');
             xmlPath = "embedded";
+        }
+    } else {
+        if (!"default".equals(xmlPath) && !"embedded".equals(xmlPath)) {
+            xmlPath = getCdPath(xmlPath);
+            if (!existsFile(xmlPath)) {
+                ctx.write("XML file " + xmlPath + " does not exist.\n\n");
+                return result(false);
+            }
         }
     }
     if (arboriPath == null) {

--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -21,6 +21,7 @@ var javaArrays = Java.type("java.util.Arrays");
 var javaPaths = Java.type("java.nio.file.Paths");
 var javaFile = Java.type("java.io.File");
 var javaFiles = Java.type("java.nio.file.Files");
+var javaFileSystems = Java.type("java.nio.file.FileSystems");
 var javaCollectors = Java.type("java.util.stream.Collectors");
 var javaPersist2XML = Java.type("oracle.dbtools.app.Persist2XML");
 var javaPattern = Java.type("java.util.regex.Pattern");
@@ -30,24 +31,29 @@ var javaParsed = Java.type("oracle.dbtools.parser.Parsed");
 var javaSqlEarley = Java.type("oracle.dbtools.parser.plsql.SqlEarley");
 var javaSystem = Java.type("java.lang.System");
 
-var getFiles = function (rootPath, extensions) {
+var getFiles = function (rootPath, extensions, ignoreMatcher) {
     var files;
     if (existsFile(rootPath)) {
-        if (isRelevantFile(rootPath, extensions)) {
+        if (isRelevantFile(rootPath, extensions, ignoreMatcher)) {
             files = javaArrays.asList(javaPaths.get(rootPath));
         } else {
             files = [];
         }
     } else {
         files = javaFiles.walk(javaPaths.get(rootPath))
-            .filter(function (f) javaFiles.isRegularFile(f) && isRelevantFile(f, extensions))
+            .filter(function (f) javaFiles.isRegularFile(f) && isRelevantFile(f, extensions, ignoreMatcher))
             .sorted()
             .collect(javaCollectors.toList());
     }
     return files;
 }
 
-var isRelevantFile = function (file, extensions) {
+var isRelevantFile = function (file, extensions, ignoreMatcher) {
+    if (ignoreMatcher != null) {
+        if (ignoreMatcher.matches(file)) {
+            return false;
+        }
+    }
     for (var i in extensions) {
         if (file.toString().toLowerCase().endsWith(extensions[i])) {
             return true;
@@ -56,12 +62,12 @@ var isRelevantFile = function (file, extensions) {
     return false;
 }
 
-var getRelevantFiles = function (files, extensions) {
+var getRelevantFiles = function (files, extensions, ignoreMatcher) {
     var relevantFiles = [];
     for (var i in files) {
         if (existsDirectory(files[i])) {
-            relevantFiles.push.apply(relevantFiles, getFiles(files[i], extensions));
-        } else if (isRelevantFile(files[i], extensions)) {
+            relevantFiles.push.apply(relevantFiles, getFiles(files[i], extensions, ignoreMatcher));
+        } else if (isRelevantFile(files[i], extensions, ignoreMatcher)) {
             relevantFiles.push(files[i]);
         }
     }
@@ -188,7 +194,10 @@ var printUsage = function (asCommand, standalone) {
     ctx.write("                  xml=default uses default advanced settings included in sqlcl\n");
     ctx.write("                  xml=embedded uses advanced settings defined in format.js\n");
     ctx.write("  arbori=<file>   path to the file containing the Arbori program for custom format settings\n");
-    ctx.write("                  arbori=default uses default Arbori program included in sqlcl\n\n");
+    ctx.write("                  arbori=default uses default Arbori program included in sqlcl\n");
+    ctx.write("  ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined\n");
+    ctx.write("                  per line. Each line represent a glob pattern. Empty lines and lines starting\n");
+    ctx.write("                  with a hash sign (#) are ignored.\n\n");
 }
 
 var getJsPath = function () {
@@ -214,6 +223,22 @@ var getCdPath = function (path) {
     }
 }
 
+var createIgnoreMatcher = function (ignorePath) {
+    var globPattern = "glob:{"
+    var lines = javaFiles.readAllLines(javaPaths.get(ignorePath));
+    for (var i=0; i < lines.size(); i++) {
+        var line = lines[i].trim();
+        if (line.length > 0 && !line.startsWith('#')) {
+            if (globPattern.length > 6) {
+                globPattern += ",";
+            }
+            globPattern += line
+        }
+    }
+    globPattern += "}";
+    return javaFileSystems.getDefault().getPathMatcher(globPattern);
+}
+
 var processAndValidateArgs = function (args) {
     var rootPath = null;
     var extArgFound = false;
@@ -222,6 +247,8 @@ var processAndValidateArgs = function (args) {
     var markdownExtensions = [];
     var xmlPath = null;
     var arboriPath = null;
+    var ignorePath = null;
+    var ignoreMatcher = null;
     var files = [];
     var result = function (valid) {
         return {
@@ -231,6 +258,7 @@ var processAndValidateArgs = function (args) {
             markdownExtensions: markdownExtensions,
             xmlPath: xmlPath,
             arboriPath: arboriPath,
+            ignoreMatcher: ignoreMatcher,
             valid: valid
         };
     }
@@ -286,6 +314,9 @@ var processAndValidateArgs = function (args) {
             }
             if (typeof configJson.arbori !== 'undefined') {
                 arboriPath = configJson.arbori;
+            }
+            if (typeof configJson.ignore !== 'undefined') {
+                ignorePath = configJson.ignore;
             }
             if (typeof configJson.files !== 'undefined') {
                 if (!Array.isArray(configJson.files)) {
@@ -343,6 +374,10 @@ var processAndValidateArgs = function (args) {
             arboriPath = args[i].substring(7);
             continue;
         }
+        if (args[i].toLowerCase().startsWith("ignore=")) {
+            ignorePath = args[i].substring(7);
+            continue;
+        }
         ctx.write("invalid argument " + args[i] + ".\n\n");
         return result(false);
     }
@@ -386,6 +421,13 @@ var processAndValidateArgs = function (args) {
             }
         }
     }
+    if (ignorePath != null) {
+        ignorePath = getCdPath(ignorePath);
+        if (!existsFile(ignorePath)) {
+            ctx.write("Ignore file " + ignorePath + " does not exist.\n\n");
+            return result(false);
+        }
+        ignoreMatcher = createIgnoreMatcher(ignorePath);
     }
     return result(true);
 }
@@ -473,9 +515,9 @@ var run = function (args) {
         } else {
             var files;
             if (options.files.length > 0) {
-                files = getRelevantFiles(options.files, options.extensions);
+                files = getRelevantFiles(options.files, options.extensions, options.ignoreMatcher);
             } else {
-                files = getFiles(options.rootPath, options.extensions);
+                files = getFiles(options.rootPath, options.extensions, options.ignoreMatcher);
             }
             formatFiles(files, formatter, options.markdownExtensions);
         }

--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -341,13 +341,6 @@ var processAndValidateArgs = function (args) {
         }
         if (args[i].toLowerCase().startsWith("arbori=")) {
             arboriPath = args[i].substring(7);
-            if (!"default".equals(arboriPath)) {
-                arboriPath = getCdPath(arboriPath);
-                if (!existsFile(getCdPath(arboriPath))) {
-                    ctx.write("file " + arboriPath + " does not exist.\n\n");
-                    return result(false);
-                }
-            }
             continue;
         }
         ctx.write("invalid argument " + args[i] + ".\n\n");
@@ -384,6 +377,15 @@ var processAndValidateArgs = function (args) {
             ctx.write('Warning: ' + arboriPath + ' not found, using "default" instead.\n\n');
             arboriPath = "default";
         }
+    } else {
+        if (!"default".equals(arboriPath)) {
+            arboriPath = getCdPath(arboriPath);
+            if (!existsFile(arboriPath)) {
+                ctx.write("Arbori file " + arboriPath + " does not exist.\n\n");
+                return result(false);
+            }
+        }
+    }
     }
     return result(true);
 }

--- a/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatWrongArgumentTest.java
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatWrongArgumentTest.java
@@ -27,6 +27,9 @@ public class FormatWrongArgumentTest extends AbstractSqlclTest {
                                   xml=embedded uses advanced settings defined in format.js
                   arbori=<file>   path to the file containing the Arbori program for custom format settings
                                   arbori=default uses default Arbori program included in sqlcl
+                  ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined
+                                  per line. Each line represent a glob pattern. Empty lines and lines starting
+                                  with a hash sign (#) are ignored.
 
                 """;
         var actual = runScript();

--- a/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatIgnoreTest.java
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatIgnoreTest.java
@@ -1,0 +1,55 @@
+package com.trivadis.plsql.formatter.sqlcl.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TvdFormatIgnoreTest extends AbstractSqlclTest {
+
+    @BeforeEach
+    public void registerCommandBeforeTest() {
+        runScript("--register");
+        byteArrayOutputStream.reset();
+    }
+
+    @Test
+    public void ignore_as_as_parameter_file_does_not_exist() {
+        var actual = runCommand( "tvdformat " + tempDir.toString() + " ignore=does_not_exist.txt");
+        Assertions.assertTrue(actual.contains("Ignore file does_not_exist.txt does not exist."));
+    }
+
+    @Test
+    public void ignore_in_json_object_file_does_not_exist() throws IOException {
+        var configFileContent = """
+                {
+                    "files":["#TEMP_DIR#"],
+                    "ignore":"does_not_exist.txt"
+                }
+                """.replace("#TEMP_DIR#", tempDir.toString());
+        final Path configFile = Paths.get(tempDir + File.separator + "config.json");
+        Files.write(configFile, configFileContent.getBytes());
+        var actual = runCommand( "tvdformat " + tempDir + File.separator + "config.json ignore=does_not_exist.txt");
+        Assertions.assertTrue(actual.contains("Ignore file does_not_exist.txt does not exist."));
+    }
+
+    @Test
+    public void ignore_two_files() throws IOException {
+        var ignoreFileContent = """
+                # ignore package bodies
+                **/*.pkb
+                
+                # Ignore files with syntax errors
+                **/*syntax*
+                """;
+        final Path ignoreFile = Paths.get(tempDir + File.separator + "ignore.txt");
+        Files.write(ignoreFile, ignoreFileContent.getBytes());
+        var actual = runCommand( "tvdformat " + tempDir.toString() + " ignore=" + tempDir + File.separator + "ignore.txt");
+        Assertions.assertTrue(actual.contains("2 of 2"));
+    }
+}

--- a/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatWrongArgumentTest.java
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatWrongArgumentTest.java
@@ -33,7 +33,10 @@ public class TvdFormatWrongArgumentTest extends AbstractSqlclTest {
                                   xml=embedded uses advanced settings defined in format.js
                   arbori=<file>   path to the file containing the Arbori program for custom format settings
                                   arbori=default uses default Arbori program included in sqlcl
-                            
+                  ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined
+                                  per line. Each line represent a glob pattern. Empty lines and lines starting
+                                  with a hash sign (#) are ignored.
+
                 """;
         var actual = runCommand("Tvdformat");
         Assertions.assertEquals(expected, actual);


### PR DESCRIPTION
Closes #162 - Add capability to exclude files from formatting
- New parameter `ignore` in `format.js`
- Extend documentation of `format.js`
- The `pre-commit` hook is left as is. 
    - Adding an ignore parameter can be done by extending the `FORMATTER_OPTS`
    - This way defining an ignore parameter is optional and no file checking logic must be applied to the hook's configuration section