### PR TITLE
Feature/issue 168 - make formatter compatible with SQLcl and SQLDev 21.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository provides formatter settings for the [coding style rules](https:/
 
 Settings are primarily provided for
 
-- [Oracle SQLcl, Version 21.3.3](https://www.oracle.com/tools/downloads/sqlcl-downloads.html)
-- [Oracle SQL Developer, Version 21.2.1](https://www.oracle.com/tools/downloads/sqldev-downloads.html)
+- [Oracle SQLcl, Version 21.4.0](https://www.oracle.com/tools/downloads/sqlcl-downloads.html)
+- [Oracle SQL Developer, Version 21.4.0](https://www.oracle.com/tools/downloads/sqldev-downloads.html)
 
 These settings have been defined and tested with the product versions mentioned above. They might not work in other versions.
 

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -6,13 +6,13 @@
     <!-- The Basics -->
     <groupId>com.trivadis.plsql.formatter</groupId>
     <artifactId>tvdformat</artifactId>
-    <version>21.3.3-SNAPSHOT</version>
+    <version>21.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
         <sqlcl.libdir>/usr/local/bin/sqlcl/lib</sqlcl.libdir>
-        <sqlcl.version>21.3.3</sqlcl.version>
+        <sqlcl.version>21.4.0</sqlcl.version>
         <graalvm.version>21.3.0</graalvm.version>
         <graalvm.native.version>21.2.0</graalvm.native.version>
         <skip.native>true</skip.native>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,13 +6,13 @@
     <!-- The Basics -->
     <groupId>com.trivadis</groupId>
     <artifactId>plsql.formatter.settings</artifactId>
-    <version>21.3.3-SNAPSHOT</version>
+    <version>21.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>17</jdk.version>
         <sqlcl.libdir>/usr/local/bin/sqlcl/lib</sqlcl.libdir>
-        <sqlcl.version>21.3.3</sqlcl.version>
+        <sqlcl.version>21.4.0</sqlcl.version>
         <graalvm.version>21.3.0</graalvm.version>
     </properties>
     <dependencies>
@@ -62,7 +62,7 @@
             <artifactId>xmlparserv2-sans-jaxp-services</artifactId>
             <version>${sqlcl.version}</version>
             <scope>system</scope>
-            <systemPath>${sqlcl.libdir}/xmlparserv2-sans-jaxp-services.jar</systemPath>
+            <systemPath>${sqlcl.libdir}/xmlparserv2_sans_jaxp_services.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>oracle.i18n</groupId>

--- a/tests/src/test/java/com/trivadis/plsql/formatter/settings/ConfiguredTestFormatter.java
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/settings/ConfiguredTestFormatter.java
@@ -42,7 +42,7 @@ public abstract class ConfiguredTestFormatter {
             URL advancedFormat = Thread.currentThread().getContextClassLoader().getResource("trivadis_advanced_format.xml"); // symbolic link
             assert advancedFormat != null;
             map = Persist2XML.read(advancedFormat);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
         return map;

--- a/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/rules/R2_indentation.java
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/rules/R2_indentation.java
@@ -1013,11 +1013,12 @@ public class R2_indentation extends ConfiguredTestFormatter {
 
         @Test
         public void start_with() throws IOException {
+            // #168 - "start with" must not start on column 1. Issue introduce in 21.4.0
             var input = """
                     select level
                     ,ename
                     from emp
-                    start with
+                     start with
                     mgr is null
                     connect by
                     prior empno = mgr;

--- a/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                    for r in /*(*/ select x.* from x join y on y.a = x.a)
                             ^^^                                         \s
                             
-                Expected: expr#,simple_expression,name_wo_function_call,iden... skipped.
+                Expected: constraint,':',"aggr_name",'COUNT',"expr_list",'JS... skipped.
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         var actual = run(runType, tempDir.toString(), "mext=");
         Assertions.assertEquals(expected, actual);
@@ -553,7 +553,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                    for r in /*(*/ select x.* from x join y on y.a = x.a)
                             ^^^                                         \s
                                                                                      
-                Expected: expr#,simple_expression,name_wo_function_call,iden... skipped.
+                Expected: constraint,':',"aggr_name",'COUNT',"expr_list",'JS... skipped.
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         var configFileContent = """
                 [


### PR DESCRIPTION
closes #168 