### PR TITLE
bugfix/issue 167 consider leading/trailing commas when adding line breaks between parameters

### DIFF
--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -1641,11 +1641,22 @@ a17_whitespace_around_node:
 a15_various:
       [node) insert_into_clause & [node^^) multi_table_insert
     | [node) subquery & [node^) multi_table_insert
-    | [node) prm_spec & [node-1) ','
     | [node) subprg_property
     | [node) ')' & [node^) create_view#[114,130)
     | [node) ')' & [node^) create_materialized_view[33,79)
 ;
+
+a15_subsequent_prm_spec_trailing_comma:
+     [node) prm_spec
+   & [node-1) ','
+   & :breaksAfterComma
+;
+a15_subsequent_prm_spec_leading_comma:
+     [node) ','
+   & [node+1) prm_spec
+   & :breaksBeforeComma
+;
+
 
 a15_is_or_as:
       [node) is_or_as
@@ -1668,6 +1679,8 @@ a15_materialized_view_column_alias:
 
 a15_line_break_before:
       a15_various
+    | a15_subsequent_prm_spec_trailing_comma
+    | a15_subsequent_prm_spec_leading_comma
     | a15_is_or_as
     | a15_view_column_alias
     | a15_materialized_view_column_alias

--- a/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/issues/Issue_167_leading_commas_and_comments.java
+++ b/tests/src/test/java/com/trivadis/plsql/formatter/settings/tests/issues/Issue_167_leading_commas_and_comments.java
@@ -1,0 +1,54 @@
+package com.trivadis.plsql.formatter.settings.tests.issues;
+
+import com.trivadis.plsql.formatter.settings.ConfiguredTestFormatter;
+import oracle.dbtools.app.Format;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class Issue_167_leading_commas_and_comments extends ConfiguredTestFormatter {
+
+    @BeforeEach
+    public void setup_non_trivadis_default_settings() {
+        getFormatter().options.put(getFormatter().idCase, Format.Case.lower);
+    }
+
+    @Test
+    public void leading_commas() {
+        getFormatter().options.put(getFormatter().breaksComma, Format.Breaks.Before);
+        var sql = """
+                create or replace package test_pkg authid definer as
+                                
+                   procedure proc(
+                      p_segment1 in         varchar2
+                    -- comment 1
+                    , p_segment2 in         varchar2
+                    , p_segment3 in         varchar2
+                    /* comment 2 */
+                    , x_status   out nocopy varchar2
+                   );
+                                
+                end test_pkg;
+                """;
+        formatAndAssert(sql);
+    }
+
+    @Test
+    public void trailing_commas() {
+        getFormatter().options.put(getFormatter().breaksComma, Format.Breaks.After);
+        var sql = """
+                create or replace package test_pkg authid definer as
+                                
+                   procedure proc(
+                      p_segment1 in         varchar2,
+                      -- comment 1
+                      p_segment2 in         varchar2,
+                      p_segment3 in         varchar2,
+                      /* comment 2 */
+                      x_status   out nocopy varchar2
+                   );
+                                
+                end test_pkg;
+                """;
+        formatAndAssert(sql);
+    }
+}


### PR DESCRIPTION
fixes #167 