### PR TITLE
Feature/issue 208 sqldev 22.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 # Targets
 **/target
 **/bin
+
+# maven-shade-plugin
+dependency-reduced-pom.xml

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ This repository provides formatter settings for the [coding style rules](https:/
 
 Settings are primarily provided for
 
-- [Oracle SQLcl, Version 21.4.1](https://www.oracle.com/tools/downloads/sqlcl-downloads.html)
-- [Oracle SQL Developer, Version 21.4.3](https://www.oracle.com/tools/downloads/sqldev-downloads.html)
+- [Oracle SQLcl, Version 22.2.0](https://www.oracle.com/tools/downloads/sqlcl-downloads.html)
+- [Oracle SQL Developer, Version 22.2.0](https://www.oracle.com/tools/downloads/sqldev-downloads.html)
 
 These settings have been defined and tested with the product versions mentioned above. They might not work in other versions.
 
-JDK 8 or 11 is required for SQLDev and SQLcl. The standalone tvdformat.jar works with JDK 8, 11, 17.
+JDK 11 is required for SQLDev and SQLcl. The standalone tvdformat.jar works with JDK 11 or newer.
 
 See [releases](https://github.com/Trivadis/plsql-formatter-settings/releases) for settings supporting older versions.
 
@@ -93,9 +93,9 @@ SQL Developer uses its own parse tree query language called Arbori for its advan
 
 #### Links
 
+- [SQL Developer 22.2 User Guide, Code Editor: Format](https://docs.oracle.com/en/database/oracle/sql-developer/22.2/rptug/sql-developer-concepts-usage.html#GUID-9421DA6E-A48A-427B-88C9-4414D83EC9D1__CODEEDITORFORMAT-C73DB981)
 - [Formatting Code With SQL Developer](https://www.salvis.com/blog/2020/04/13/formatting-code-with-sql-developer/)
 - [Formatter Callback Functions](https://www.salvis.com/blog/2020/11/12/formatter-callback-functions/)
-- [SQL Developer 20.4 User Guide, Code Editor: Format](https://docs.oracle.com/en/database/oracle/sql-developer/20.4/rptug/sql-developer-concepts-usage.html#GUID-9421DA6E-A48A-427B-88C9-4414D83EC9D1__GUID-64BE7F6C-37D1-4D21-96A5-E9A19C7D3543)
 - [Arbori Starter Manual](https://vadimtropashko.files.wordpress.com/2017/02/arbori-starter-manual.pdf)
 - [Semantic Analysis with Arbori](https://vadimtropashko.files.wordpress.com/2019/11/arbori.pdf)
 - [Arbori Semantic Actions](https://vadimtropashko.wordpress.com/2019/08/01/arbori-semantic-actions/)

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -1299,7 +1299,7 @@ a6_percent:
 ;
 
 a6_brackets:
-      [node) '['
+    [node) '['
 ;
 
 a6_host_variable:

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -117,6 +117,9 @@ skipWhiteSpaceBeforeNode:
     var doNotCallCallbackFunction;
 }
 
+-- In SQLDev 22.2.0 the formatter introduced a check that looks for "order_by_clause___0" in the Arbori program.
+-- There is no need to define a query that uses it. Using it in the comment is good enough.
+
 -- ====================================================================================================================
 -- Phase 1 - Initialization and pre-processing.
 -- ====================================================================================================================
@@ -1046,7 +1049,7 @@ a13_nodes:
     | [node) function_expression
     | [node) dotted_name
     | [node) dotted_expr
-    | [node) column[4,12)
+    | [node) column___0
     | [node) compound_expression & ![node^) compound_expression
     | [node) pls_expr & ![node^) pls_expr
     | [node) "expr_list" & ![node^) "expr_list"
@@ -1745,8 +1748,8 @@ a15_various:
       [node) insert_into_clause & [node^^) multi_table_insert
     | [node) subquery & [node^) multi_table_insert
     | [node) subprg_property
-    | [node) ')' & [node^) create_view#[114,130)
-    | [node) ')' & [node^) create_materialized_view[33,79)
+    | [node) ')' & [node^) create_view#___0
+    | [node) ')' & [node^) create_materialized_view2___0
 ;
 
 a15_subsequent_prm_spec_trailing_comma:
@@ -1769,13 +1772,13 @@ a15_is_or_as:
 ;
 
 a15_view_column_alias:
-      [parent) create_view#[114,130)
+      [parent) create_view#___0
     & [node) alias_in_out_constraints
     & parent < node
 ;
 
 a15_materialized_view_column_alias:
-      [parent) create_materialized_view[33,79)
+      [parent) create_materialized_view2___0
     & [node) identifier
     & parent < node
 ;
@@ -2291,7 +2294,7 @@ o10_join_clause_break_keywords:
               & ![keyword-1) 'CROSS'
               & ![keyword-1) 'NATURAL'
               & ![keyword-1) outer_join_type
-              & ![keyword-1) "inner_cross_join_clause"[26,55)
+              & ![keyword-1) "inner_cross_join_clause"___0
           --| [keyword) 'PARTITION'
           | [keyword) 'ON'
           | [keyword) 'USING'
@@ -2772,7 +2775,7 @@ r2_common:
     | [node) field_list & ![node^) field_list
     | [node) fml_part
     | [node) paren_expr_list
-    | [node) "expr_list" & [node-1) '(' & [node^) in_condition[24,35)
+    | [node) "expr_list" & [node-1) '(' & [node^) in_condition___0
     | [node) xmltable
     | [node) json_table
     | [node) JSON_columns_clause
@@ -2796,7 +2799,7 @@ r2_common:
     | [node) analytic_clause & ![node^) over_clause
     | [node) 'RETURN' & [node^) subprg_spec
     | [node-1) 'RETURN' & [node^) stmt
-    | [node) plsql_declarations & ([node^) with_clause | [node^) with_clause[12,20))
+    | [node) plsql_declarations & ([node^) with_clause | [node^) with_clause___0)
 ;
 
 r2_flowcontrol_condition:
@@ -2813,9 +2816,9 @@ r2_flowcontrol_condition:
 ;
 
 r2_case_expression:
-      [node) simple_case_expression[4,27)#
+      [node) simple_case_expression___0#
     | [node) searched_case_expression#
-    | [node) expr & [node^) simple_case_expression[4,27)#
+    | [node) expr & [node^) simple_case_expression___0#
     | [node) else_clause & [node^) case_expression
     | [node) expr & [node^) else_clause & [node^^) case_expression
     | [node) expr & [node^) searched_case_expression#
@@ -2833,18 +2836,18 @@ r2_case_expression_plsql:
 ;
 
 r2_view:
-      [node) create_view#[114,130)
+      [node) create_view#___0
     | [node) subquery & [node^) create_view#
 ;
 
 r2_materialized_view:
-      [node) create_materialized_view[33,79)
+      [node) create_materialized_view2___0
     | [node) subquery & [node^) create_materialized_view
-    | [node) create_materialized_view[91,136)
-    | [node) create_materialized_view[136,174)
+    | [node) create_materialized_view3___2
+    | [node) create_materialized_view3___3
     | [node) create_mv_refresh
     | [node) 'DISABLE' & [node^) create_materialized_view
-    | [node) create_materialized_view[200,210)
+    | [node) create_materialized_view3___0
     | [node) query_rewrite_clause
 ;
 
@@ -2861,7 +2864,7 @@ r2_body:
 ;
 
 r2_single_table_insert:
-      [node) insert_into_clause[13,25)
+      [node) insert_into_clause___0
     | [node) par_expr_list
 ;
 
@@ -2880,8 +2883,8 @@ r2_multi_table_insert:
 r2_merge_insert_clause:
       [parent) merge_insert_clause
     & (
-          [node) merge_insert_clause[23,35) & [node-1) 'INSERT'
-        | [node) merge_insert_clause[43,50) & [node-1) 'VALUES'
+          [node) merge_insert_clause___0 & [node-1) 'INSERT'
+        | [node) merge_insert_clause___2 & [node-1) 'VALUES'
     )
     & parent < node
 ;
@@ -2921,12 +2924,12 @@ r2_decrement_left_margin:
                 | [node^) xmltable
                 | [node^) json_table
                 | [node^) JSON_columns_clause
-                | [node^) create_view#[114,130)
-                | [node^) create_materialized_view[33,79)
-                | [node^) insert_into_clause[13,25)
+                | [node^) create_view#___0
+                | [node^) create_materialized_view2___0
+                | [node^) insert_into_clause___0
                 | [node^) par_expr_list
-                | [node^) merge_insert_clause[23,35)
-                | [node^) merge_insert_clause[43,50)
+                | [node^) merge_insert_clause___0
+                | [node^) merge_insert_clause___2
                 | [node^) function
                 | [node^) function_expression
                 | [node^) "(x,y,z)"
@@ -2970,7 +2973,7 @@ r2_increment_left_margin_by_keyword_outside_update_delete_merge:
     -- delete statement
     | [node) 'FROM' & [keyword) 'DELETE' & [node^) delete & keyword+1 = node
     -- merge statement
-    | [node) merge_update_clause[36,56) & [keyword) 'SET' & [node^) merge_update_clause & keyword^ = node^
+    | [node) merge_update_clause___2 & [keyword) 'SET' & [node^) merge_update_clause & keyword^ = node^
 -> {
     addMarginByName(tuple.get("node"), 6, target.src.get(tuple.get("keyword").from).content,
         "r2_increment_left_margin_by_keyword_outside_update_delete_merge");
@@ -2978,7 +2981,7 @@ r2_increment_left_margin_by_keyword_outside_update_delete_merge:
 
 -- use merge keyword for right alignment (5 chars)
 r2_increment_left_margin_by_keyword_outside_node_for_merge:
-      [node) subquery & [keyword) 'USING' & [node^) merge & keyword+1 = node
+      [node) merge___2 & [keyword) 'USING' & [node^) merge & keyword+1 = node
     | [node) condition & [keyword) 'ON' & [node^) merge & keyword+2 = node
     | [node) ')' & [keyword) 'ON' & [node^) merge & keyword+3 = node
 -> {
@@ -3018,10 +3021,10 @@ r2_increment_left_margin_by_keyword_inside_node_for_merge:
 }
 
 r2_indent_single_line_clauses:
-      [node) insert_into_clause[13,25)
-    | [node) values_clause[12,20)
-    | [node) merge_insert_clause[23,35) & [node-1) 'INSERT'
-    | [node) merge_insert_clause[43,50) & [node-1) 'VALUES'
+      [node) insert_into_clause___0
+    | [node) values_clause___0
+    | [node) merge_insert_clause___0 & [node-1) 'INSERT'
+    | [node) merge_insert_clause___2 & [node-1) 'VALUES'
 -> {
     var node = tuple.get("node");
     if (getIndent(node.from).indexOf("\n") != -1) {
@@ -3245,7 +3248,7 @@ r7_select:
     & ![keyword^) analytic_clause
     & ![keyword^^) function
     & ![keyword^) function
-    & ![keyword^) collect[33,52) -- order by clause in collect function
+    & ![keyword^) collect___1 -- order by clause in collect function
 ;
 
 r7_single_table_insert:
@@ -3267,7 +3270,7 @@ r7_single_table_insert:
 r7_multi_table_insert_uncond:
       [parent) insert
     & [insert) multi_table_insert
-    & [uncond) multi_table_insert[12,24)
+    & [uncond) multi_table_insert___0
     & (
           [keyword) 'ALL'
         | [keyword) 'FIRST'
@@ -3823,7 +3826,7 @@ a9_declarations:
 }
 
 a9_find_columns:
-      [scope) XMLTABLE_options[19,37)
+      [scope) XMLTABLE_options___0
     & [node) XML_table_column
     & [comma) ','
     & scope < node
@@ -3857,8 +3860,8 @@ a9_align_xmltable_columns:
 }
 
 a9_find_datatypes:
-     [scope) XMLTABLE_options[19,37)
-   & [node) XML_table_column[5,72)
+     [scope) XMLTABLE_options___0
+   & [node) XML_table_column___3
    & [path) 'PATH'
    & scope < node
    & node < path
@@ -3922,7 +3925,7 @@ a20_align_json_table_columns:
 a20_find_datatypes:
      [scope) JSON_columns_clause
    & [node) JSON_value_return_type
-   & [path) "JSON_value_column[5,10)"
+   & [path) "JSON_value_column___0"
    & scope < node
    & path = node+1
 -> {

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -1231,8 +1231,11 @@ a5_brackets:
 ;
 
 a5_indicator_variable:
-      [node) bind_var
-    & [node-1) bind_var
+      [node) identifier
+    & [node-1) ':'
+    & [node-2) identifier
+    & [node-3) ':'
+    & [node^) bind_var
 ;
 
 a5_star_star:
@@ -1300,8 +1303,7 @@ a6_brackets:
 ;
 
 a6_host_variable:
-      [node) ':'
-    & [node^) bind_var
+    [node^) bind_var
 ;
 
 a6_pragma_exception_init:

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -3555,9 +3555,12 @@ o8_variables:
 
 o8_records:
       [scope) ty_def
-    & [node-1) identifier
-    & [node^) field
+    & [first) identifier
+    & first = node-1
+    & [parent) field
+    & parent = node^
     & scope < node^
+    & [first = [parent
 ;
 
 o8_attributes:

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -2365,7 +2365,7 @@ o11_break_on_subqueries:
 -- --------------------------------------------------------------------------------------------------------------------
 
 a16_select:
-      [parent) subquery
+      [parent) query_block
     & (
           [node) 'FROM' & ![node^) expr
         | [node) 'WHERE'
@@ -3052,13 +3052,13 @@ r2_indent_name_list_after_fetch_into:
 }
 
 r2_subquery_all:
-      [node) subquery
+      [node) query_block
     & [from) from_clause
     & node < from
 ;
 
 r2_subquery_set:
-      [node) subquery
+      [node) query_block
     & [from) from_clause
     & node < from
     & [from^-1) SET_OPER -- must not negate this predicate in SQLDev 21.2.1, see issue #133

--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -17,7 +17,7 @@
 include "std.arbori"
 
 /**
- * Lightweight Formatter for SQL Developer and SQLcl, version 22.1.0-SNAPSHOT
+ * Lightweight Formatter for SQL Developer and SQLcl, version 22.2.0-SNAPSHOT
  * The idea is to keep the code formatted "as is" and apply chosen formatting rules only.
  *
  * The Arbori program is processed from top to bottom.

--- a/sqlcl/README.md
+++ b/sqlcl/README.md
@@ -6,7 +6,7 @@ You can apply the formatter settings in SQL Developer. Another option is to appl
 
 ## Why not Use `FORMAT FILE`?
 
-Yes, you can use the built-in `FORMAT FILE` command. Here's the help output from SQLcl 21.3.2:
+Yes, you can use the built-in `FORMAT FILE` command. Here's the help output from SQLcl 22.2.0:
 
 ```
 FORMAT
@@ -28,7 +28,7 @@ We recommend you download, clone, or fork this repository when you plan to use [
 However, [`format.js`](format.js) also works as a standalone script. Here's the usage:
 
 ```
-Trivadis PL/SQL & SQL Formatter (format.js), version 22.1.0-SNAPSHOT
+Trivadis PL/SQL & SQL Formatter (format.js), version 22.2.0-SNAPSHOT
 
 usage: script format.js <rootPath> [options]
 

--- a/sqlcl/format.js
+++ b/sqlcl/format.js
@@ -49,7 +49,7 @@ var javaSqlEarley = Java.type("oracle.dbtools.parser.plsql.SqlEarley");
 var javaProgram = Java.type("oracle.dbtools.arbori.Program");
 
 var getVersion = function() {
-    return "22.1.0-SNAPSHOT";
+    return "22.2.0-SNAPSHOT";
 }
 
 var getFiles = function (rootPath, extensions, ignoreMatcher) {

--- a/standalone/install_sqlcl_libs.sh
+++ b/standalone/install_sqlcl_libs.sh
@@ -15,7 +15,7 @@ if ! test -f "${SQLCL_LIBDIR}/dbtools-common.jar"; then
 fi
 
 # define common Maven properties
-SQLCL_VERSION="21.4.1"
+SQLCL_VERSION="22.2.0"
 
 # install JAR files in local Maven repository, these libs are not available in public Maven repositories
 mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file -Dfile=$SQLCL_LIBDIR/dbtools-common.jar

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -6,15 +6,15 @@
     <!-- The Basics -->
     <groupId>com.trivadis.plsql.formatter</groupId>
     <artifactId>tvdformat</artifactId>
-    <version>22.1.0-SNAPSHOT</version>
+    <version>22.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>8</jdk.version>
+        <jdk.version>11</jdk.version>
         <jdk.test.version>17</jdk.test.version>
-        <sqlcl.version>21.4.1</sqlcl.version>
-        <graalvm.version>22.0.0.2</graalvm.version>
-        <native.maven.plugin.version>0.9.9</native.maven.plugin.version>
+        <sqlcl.version>22.2.0</sqlcl.version>
+        <graalvm.version>22.1.0.1</graalvm.version>
+        <native.maven.plugin.version>0.9.12</native.maven.plugin.version>
         <skip.native>true</skip.native>
         <disable.logging>true</disable.logging>
     </properties>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.32</version>
+            <version>1.7.36</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -138,7 +138,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -288,7 +288,7 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <version>3.8.1</version>
+                        <version>3.10.1</version>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <!-- different Java version for main and test -->
@@ -312,7 +312,7 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <version>3.8.1</version>
+                        <version>3.10.1</version>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <!-- IDEA requires same Java version for main and test -->

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/settings/tests/grammar/plsql/Record_variable_declaration.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/settings/tests/grammar/plsql/Record_variable_declaration.java
@@ -149,8 +149,8 @@ public class Record_variable_declaration extends ConfiguredTestFormatter {
                    type full_name is varray(2) of varchar2(20);
                                 
                    type contact is record(
-                         name full_name := full_name('John', 'Smith'),  -- varray field
-                         phone          employees.phone_number%type
+                         name  full_name := full_name('John', 'Smith'),  -- varray field
+                         phone employees.phone_number%type
                       );
                                 
                    friend contact;

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                    for r in /*(*/ select x.* from x join y on y.a = x.a)
                             ^^^                                         \s
                             
-                Expected: constraint,':',"aggr_name",'COUNT',"expr_list",'JS... skipped.
+                Expected: constraint,':',"aggr_name",'COUNT','-','(','JSON_T... skipped.
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         var actual = run(runType, tempDir.toString(), "mext=");
         Assertions.assertEquals(expected, actual);
@@ -553,7 +553,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                    for r in /*(*/ select x.* from x join y on y.a = x.a)
                             ^^^                                         \s
                                                                                      
-                Expected: constraint,':',"aggr_name",'COUNT',"expr_list",'JS... skipped.
+                Expected: constraint,':',"aggr_name",'COUNT','-','(','JSON_T... skipped.
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         var configFileContent = """
                 [

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
@@ -134,12 +134,12 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                       l_int    integer;
                    begin
                       << integer_tokens >> loop
-                         l_int           := to_number(regexp_substr(
-                                                         in_integers,
-                                                         in_pattern,
-                                                         1,
-                                                         l_pos
-                                            ));
+                         l_int           := to_number ( regexp_substr(
+                            in_integers,
+                            in_pattern,
+                            1,
+                            l_pos
+                         ) );
                          exit integer_tokens when l_int is null;
                          l_result.extend;
                          l_result(l_pos) := l_int;
@@ -197,7 +197,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                    BEGIN
                       <<integer_tokens>>
                       LOOP
-                         l_int           := to_number(regexp_substr(in_integers, in_pattern, 1, l_pos));
+                         l_int           := TO_NUMBER(regexp_substr(in_integers, in_pattern, 1, l_pos));
                          EXIT integer_tokens WHEN l_int IS NULL;
                          l_result.extend;
                          l_result(l_pos) := l_int;
@@ -252,7 +252,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                         l_int    INTEGER;
                     BEGIN
                         << integer_tokens >> LOOP
-                            l_int := to_number(regexp_substr(in_integers, in_pattern, 1, l_pos));
+                            l_int := TO_NUMBER ( regexp_substr(in_integers, in_pattern, 1, l_pos) );
                             EXIT integer_tokens WHEN l_int IS NULL;
                             l_result.extend;
                             l_result(l_pos) := l_int;
@@ -317,12 +317,12 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                       l_int    integer;
                    begin
                       << integer_tokens >> loop
-                         l_int           := to_number(regexp_substr(
-                                                         in_integers,
-                                                         in_pattern,
-                                                         1,
-                                                         l_pos
-                                            ));
+                         l_int           := to_number ( regexp_substr(
+                            in_integers,
+                            in_pattern,
+                            1,
+                            l_pos
+                         ) );
                          exit integer_tokens when l_int is null;
                          l_result.extend;
                          l_result(l_pos) := l_int;


### PR DESCRIPTION
Closes #208 Update settings for SQLDev 22.2.0 and SQLcl 22.2.0
- use latest released versions for all dependencies
- fix unknown grammar symbols
- fix grammar incompatibilities
- fix test cases
- new SQLcl libraries requires JDK 11 (or newer)
- newer JDK versions can be used if they provide an alternative for Nashorn