### PR TITLE
Bugfix/issue 218 indent column aliases

### DIFF
--- a/settings/sql_developer/trivadis_custom_format.arbori
+++ b/settings/sql_developer/trivadis_custom_format.arbori
@@ -2806,6 +2806,7 @@ r2_common:
     | [node) 'RETURN' & [node^) subprg_spec
     | [node-1) 'RETURN' & [node^) stmt
     | [node) plsql_declarations & ([node^) with_clause | [node^) with_clause___0)
+    | [node) colmapped_query_name___0
 ;
 
 r2_flowcontrol_condition:
@@ -2942,6 +2943,7 @@ r2_decrement_left_margin:
                 | [node^) XML_attributes_clause
                 | [node^^) analytic_function
                 | [node^) external_parameter_list
+                | [node^) colmapped_query_name___0
             )
     | [node) 'XMLTABLE' & [node^) xmltable
     | [node) 'JSON_TABLE' & [node^) json_table

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/settings/tests/issues/Issue_218_indent_column_aliases_with_clause.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/settings/tests/issues/Issue_218_indent_column_aliases_with_clause.java
@@ -1,0 +1,27 @@
+package com.trivadis.plsql.formatter.settings.tests.issues;
+
+import com.trivadis.plsql.formatter.settings.ConfiguredTestFormatter;
+import org.junit.jupiter.api.Test;
+
+public class Issue_218_indent_column_aliases_with_clause extends ConfiguredTestFormatter {
+
+    @Test
+    public void with_clause() {
+        var sql = """
+                with
+                   employees (
+                      id,
+                      name,
+                      salary
+                   ) as (
+                      select empno,
+                             ename,
+                             sal
+                        from emp
+                   )
+                select *
+                  from employees;
+                """;
+        formatAndAssert(sql);
+    }
+}


### PR DESCRIPTION
fixes #218 Missing indentation of column aliases within subquery factory clause