### PR TITLE
Feature/issue 229 suppress syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides formatter settings for the [coding style rules](https:/
 
 Settings are primarily provided for
 
-- [Oracle SQLcl, Version 22.2.0](https://www.oracle.com/tools/downloads/sqlcl-downloads.html)
+- [Oracle SQLcl, Version 22.2.1](https://www.oracle.com/tools/downloads/sqlcl-downloads.html)
 - [Oracle SQL Developer, Version 22.2.0](https://www.oracle.com/tools/downloads/sqldev-downloads.html)
 
 These settings have been defined and tested with the product versions mentioned above. They might not work in other versions.

--- a/sqlcl/README.md
+++ b/sqlcl/README.md
@@ -28,7 +28,7 @@ We recommend you download, clone, or fork this repository when you plan to use [
 However, [`format.js`](format.js) also works as a standalone script. Here's the usage:
 
 ```
-Trivadis PL/SQL & SQL Formatter (format.js), version 22.2.0
+Trivadis PL/SQL & SQL Formatter (format.js), version 22.2.1
 
 usage: script format.js <rootPath> [options]
 
@@ -48,6 +48,11 @@ options:
   ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined
                   per line. Each line represent a glob pattern. Empty lines and lines starting
                   with a hash sign (#) are ignored.
+  serr=<scope>    scope of syntax errors to be reported. By default all errors are reported.
+                  serr=none reports no syntax errors
+                  serr=all reports all syntax errors
+                  serr=ext reports syntax errors for files defined with ext option
+                  serr=mext reports syntax errors for files defined with mext option
   --help, -h,     print this help screen and exit
   --version, -v   print version and exit
   --register, -r  register SQLcl command tvdformat and exit
@@ -64,7 +69,7 @@ script (...)/plsql-formatter-settings/sqlcl/format.js --register
 Afterwards you can type `tvdformat` to get this usage help:
 
 ```
-Trivadis PL/SQL & SQL Formatter (tvdformat), version 22.2.0
+Trivadis PL/SQL & SQL Formatter (tvdformat), version 22.2.1
 
 usage: tvdformat <rootPath> [options]
 
@@ -84,6 +89,11 @@ options:
   ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined
                   per line. Each line represent a glob pattern. Empty lines and lines starting
                   with a hash sign (#) are ignored.
+  serr=<scope>    scope of syntax errors to be reported. By default all errors are reported.
+                  serr=none reports no syntax errors
+                  serr=all reports all syntax errors
+                  serr=ext reports syntax errors for files defined with ext option
+                  serr=mext reports syntax errors for files defined with mext option
   --help, -h,     print this help screen and exit
   --version, -v   print version and exit
 ```

--- a/standalone/install_sqlcl_libs.sh
+++ b/standalone/install_sqlcl_libs.sh
@@ -15,11 +15,13 @@ if ! test -f "${SQLCL_LIBDIR}/dbtools-common.jar"; then
 fi
 
 # define common Maven properties
-SQLCL_VERSION="22.2.0"
+SQLCL_VERSION="22.2.1"
 
 # install JAR files in local Maven repository, these libs are not available in public Maven repositories
-mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file -Dfile=$SQLCL_LIBDIR/dbtools-common.jar
-mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file -Dfile=$SQLCL_LIBDIR/dbtools-sqlcl.jar
+mvn install:install-file -Dfile=$SQLCL_LIBDIR/dbtools-common.jar \
+        -DgroupId=oracle.dbtools -DartifactId=dbtools-common -Dversion=$SQLCL_VERSION -Dpackaging=jar
+mvn install:install-file -Dfile=$SQLCL_LIBDIR/dbtools-sqlcl.jar \
+        -DgroupId=oracle.dbtools -DartifactId=dbtools-sqlcl -Dversion=$SQLCL_VERSION -Dpackaging=jar
 mvn install:install-file -Dfile=$SQLCL_LIBDIR/xmlparserv2_sans_jaxp_services.jar \
         -DgroupId=oracle.xml -DartifactId=xmlparserv2-sans-jaxp-services -Dversion=$SQLCL_VERSION -Dpackaging=jar
 mvn install:install-file -Dfile=$SQLCL_LIBDIR/orai18n.jar \

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>11</jdk.version>
         <jdk.test.version>17</jdk.test.version>
-        <sqlcl.version>22.2.0</sqlcl.version>
+        <sqlcl.version>22.2.1</sqlcl.version>
         <graalvm.version>22.2.0</graalvm.version>
         <native.maven.plugin.version>0.9.13</native.maven.plugin.version>
         <reflections.version>0.10.2</reflections.version>

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
@@ -602,4 +602,79 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
         Assertions.assertEquals(expectedContent, actualContent);
     }
 
+    public void process_dir_all_errors(final RunType runType) {
+        // console output
+        var expected = """
+                                
+                Formatting file 1 of 4: #TEMP_DIR##FILE_SEP#markdown.md... #1... done... #2... Syntax Error at line 6, column 13
+                                
+                                
+                    for r in /*(*/ select x.* from x join y on y.a = x.a)
+                             ^^^                                         \s
+                                
+                Expected: constraint,':',"aggr_name",'COUNT','-','(','JSON_T... skipped... #3... done... done.
+                Formatting file 2 of 4: #TEMP_DIR##FILE_SEP#package_body.pkb... done.
+                Formatting file 3 of 4: #TEMP_DIR##FILE_SEP#query.sql... done.
+                Formatting file 4 of 4: #TEMP_DIR##FILE_SEP#syntax_error.sql... Syntax Error at line 6, column 12
+                                
+                                
+                   for r in /*(*/ select x.* from x join y on y.a = x.a)
+                            ^^^                                         \s
+                                
+                Expected: constraint,':',"aggr_name",'COUNT','-','(','JSON_T... skipped.
+                """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
+        var actual = run(runType, tempDir.toString());
+        Assertions.assertEquals(expected, actual);
+    }
+
+    public void process_dir_mext_errors(final RunType runType) {
+        // console output
+        var expected = """
+                                
+                Formatting file 1 of 4: #TEMP_DIR##FILE_SEP#markdown.md... #1... done... #2... Syntax Error at line 6, column 13
+                                
+                                
+                    for r in /*(*/ select x.* from x join y on y.a = x.a)
+                             ^^^                                         \s
+                                
+                Expected: constraint,':',"aggr_name",'COUNT','-','(','JSON_T... skipped... #3... done... done.
+                Formatting file 2 of 4: #TEMP_DIR##FILE_SEP#package_body.pkb... done.
+                Formatting file 3 of 4: #TEMP_DIR##FILE_SEP#query.sql... done.
+                Formatting file 4 of 4: #TEMP_DIR##FILE_SEP#syntax_error.sql... skipped.
+                """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
+        var actual = run(runType, tempDir.toString(), "serr=mext");
+        Assertions.assertEquals(expected, actual);
+    }
+
+    public void process_dir_ext_errors(final RunType runType) {
+        // console output
+        var expected = """
+                                
+                Formatting file 1 of 4: #TEMP_DIR##FILE_SEP#markdown.md... #1... done... #2... skipped... #3... done... done.
+                Formatting file 2 of 4: #TEMP_DIR##FILE_SEP#package_body.pkb... done.
+                Formatting file 3 of 4: #TEMP_DIR##FILE_SEP#query.sql... done.
+                Formatting file 4 of 4: #TEMP_DIR##FILE_SEP#syntax_error.sql... Syntax Error at line 6, column 12
+                                
+                                
+                   for r in /*(*/ select x.* from x join y on y.a = x.a)
+                            ^^^                                         \s
+                                
+                Expected: constraint,':',"aggr_name",'COUNT','-','(','JSON_T... skipped.
+                """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
+        var actual = run(runType, tempDir.toString(), "serr=ext");
+        Assertions.assertEquals(expected, actual);
+    }
+
+    public void process_dir_no_errors(final RunType runType) {
+        // console output
+        var expected = """
+                                
+                Formatting file 1 of 4: #TEMP_DIR##FILE_SEP#markdown.md... #1... done... #2... skipped... #3... done... done.
+                Formatting file 2 of 4: #TEMP_DIR##FILE_SEP#package_body.pkb... done.
+                Formatting file 3 of 4: #TEMP_DIR##FILE_SEP#query.sql... done.
+                Formatting file 4 of 4: #TEMP_DIR##FILE_SEP#syntax_error.sql... skipped.
+                """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
+        var actual = run(runType, tempDir.toString(), "serr=none");
+        Assertions.assertEquals(expected, actual);
+    }
 }

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractFormatTest.java
@@ -361,8 +361,8 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
 
     public void process_markdown_only(final RunType runType) {
         // run
-        var actualConsole = run(runType, tempDir.toString(), "ext=");
-        Assertions.assertTrue(actualConsole.contains("Formatting file 1 of 1: " + tempDir.toString() + File.separator + "markdown.md... done."));
+        var actualConsole = run(runType, tempDir.toString(), "ext=none", "serr=ext");
+        Assertions.assertTrue(actualConsole.contains("Formatting file 1 of 1: " + tempDir.toString() + File.separator + "markdown.md... #1... done... #2... skipped... #3... done... done."));
 
         // markdown.md
         var actualMarkdown = getFormattedContent("markdown.md");
@@ -469,7 +469,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
         var expected = """
                                 
                 Formatting file 1 of 2: #TEMP_DIR##FILE_SEP#query.sql... done.
-                Formatting file 2 of 2: #TEMP_DIR##FILE_SEP#markdown.md... done.
+                Formatting file 2 of 2: #TEMP_DIR##FILE_SEP#markdown.md... #1... done... #2... skipped... #3... done... done.
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         var configFileContent = """
                 [
@@ -480,7 +480,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         final Path configFile = Paths.get(tempDir + File.separator + "config.json");
         Files.write(configFile, configFileContent.getBytes());
-        var actual = run(runType, configFile.toString());
+        var actual = run(runType, configFile.toString(), "serr=ext");
         Assertions.assertEquals(expected, actual);
     }
 
@@ -488,7 +488,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
         var expected = """
                                 
                 Formatting file 1 of 2: #TEMP_DIR##FILE_SEP#query.sql... done.
-                Formatting file 2 of 2: #TEMP_DIR##FILE_SEP#markdown.md2... done.
+                Formatting file 2 of 2: #TEMP_DIR##FILE_SEP#markdown.md2... #1... done... #2... skipped... #3... done... done.
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         Files.move(Paths.get(tempDir + File.separator + "markdown.md"), Paths.get(tempDir.toString() + File.separator + "markdown.md2"));
         var configFileContent = """
@@ -506,7 +506,7 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         final Path configFile = Paths.get(tempDir + File.separator + "config.json");
         Files.write(configFile, configFileContent.getBytes());
-        var actual = run(runType, configFile.toString());
+        var actual = run(runType, configFile.toString(), "serr=ext");
         Assertions.assertEquals(expected, actual);
         var original = getOriginalContent("markdown.md");
         var processed = getFormattedContent("markdown.md2");
@@ -537,14 +537,14 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         final Path configFile = Paths.get(tempDir + File.separator + "config.json");
         Files.write(configFile, configFileContent.getBytes());
-        var actual = run(runType, configFile.toString(), "mext=md2");
+        var actual = run(runType, configFile.toString(), "mext=md2, serr=ext");
         Assertions.assertEquals(expected, actual);
     }
 
     public void process_config_dir_array(final RunType runType) throws IOException {
         var expected = """
                                 
-                Formatting file 1 of 4: #TEMP_DIR##FILE_SEP#markdown.md... done.
+                Formatting file 1 of 4: #TEMP_DIR##FILE_SEP#markdown.md... #1... done... #2... skipped... #3... done... done.
                 Formatting file 2 of 4: #TEMP_DIR##FILE_SEP#package_body.pkb... done.
                 Formatting file 3 of 4: #TEMP_DIR##FILE_SEP#query.sql... done.
                 Formatting file 4 of 4: #TEMP_DIR##FILE_SEP#syntax_error.sql... Syntax Error at line 6, column 12
@@ -562,14 +562,14 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
         final Path configFile = Paths.get(tempDir + File.separator + "config.json");
         Files.write(configFile, configFileContent.getBytes());
-        var actual = run(runType, configFile.toString());
+        var actual = run(runType, configFile.toString(), "serr=ext");
         Assertions.assertEquals(expected, actual);
     }
 
-    public void process_sql_txt_default(final RunType runType) throws IOException {
+    public void process_sql_txt_default(final RunType runType) {
         var expected = """
                             
-                """.toString();
+                """;
         final Path file = Paths.get(tempDir.toString() + File.separator + "sql.txt");
         var actual = run(runType, file.toString());
         Assertions.assertEquals(expected, actual);
@@ -580,24 +580,24 @@ public abstract class AbstractFormatTest extends AbstractSqlclTest {
                 from
                 dual
                 ;
-                """.toString();
+                """;
         var actualContent = getFormattedContent("sql.txt");
         Assertions.assertEquals(expectedContent, actualContent);
     }
 
-    public void process_sql_txt_force(final RunType runType) throws IOException {
+    public void process_sql_txt_force(final RunType runType) {
         var expected = """
                 
                 Formatting file 1 of 1: #TEMP_DIR##FILE_SEP#sql.txt... done.
                 """.replace("#TEMP_DIR#", tempDir.toString()).replace("#FILE_SEP#", File.separator);
-        final Path file = Paths.get(tempDir.toString() + File.separator + "sql.txt");
+        final Path file = Paths.get(tempDir + File.separator + "sql.txt");
         var actual = run(runType, file.toString(), "ext=txt");
         Assertions.assertEquals(expected, actual);
 
         var expectedContent = """
                 select *
                   from dual;
-                """.toString();
+                """;
         var actualContent = getFormattedContent("sql.txt");
         Assertions.assertEquals(expectedContent, actualContent);
     }

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatHelpTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatHelpTest.java
@@ -26,6 +26,11 @@ public class FormatHelpTest extends AbstractSqlclTest {
               ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined
                               per line. Each line represent a glob pattern. Empty lines and lines starting
                               with a hash sign (#) are ignored.
+              serr=<scope>    scope of syntax errors to be reported. By default all errors are reported.
+                              serr=none reports no syntax errors
+                              serr=all reports all syntax errors
+                              serr=ext reports syntax errors for files defined with ext option
+                              serr=mext reports syntax errors for files defined with mext option
               --help, -h,     print this help screen and exit
               --version, -v   print version and exit
               --register, -r  register SQLcl command tvdformat and exit

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatTest.java
@@ -62,12 +62,12 @@ public class FormatTest extends AbstractFormatTest {
     }
 
     @Test
-    public void process_sql_txt_default() throws IOException {
+    public void process_sql_txt_default() {
         process_sql_txt_default(RunType.FormatJS);
     }
 
     @Test
-    public void process_sql_txt_force() throws IOException {
+    public void process_sql_txt_force() {
         process_sql_txt_force(RunType.FormatJS);
     }
 }

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatTest.java
@@ -70,4 +70,25 @@ public class FormatTest extends AbstractFormatTest {
     public void process_sql_txt_force() {
         process_sql_txt_force(RunType.FormatJS);
     }
+
+    @Test
+    public void process_dir_all_errors() {
+        process_dir_all_errors(RunType.FormatJS);
+    }
+
+    @Test
+    public void process_dir_mext_errors() {
+        process_dir_mext_errors(RunType.FormatJS);
+    }
+
+    @Test
+    public void process_dir_ext_errors() {
+        process_dir_ext_errors(RunType.FormatJS);
+    }
+
+    @Test
+    public void process_dir_no_errors() {
+        process_dir_no_errors(RunType.FormatJS);
+    }
+
 }

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatWrongArgumentTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/FormatWrongArgumentTest.java
@@ -31,6 +31,11 @@ public class FormatWrongArgumentTest extends AbstractSqlclTest {
                   ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined
                                   per line. Each line represent a glob pattern. Empty lines and lines starting
                                   with a hash sign (#) are ignored.
+                  serr=<scope>    scope of syntax errors to be reported. By default all errors are reported.
+                                  serr=none reports no syntax errors
+                                  serr=all reports all syntax errors
+                                  serr=ext reports syntax errors for files defined with ext option
+                                  serr=mext reports syntax errors for files defined with mext option
                   --help, -h,     print this help screen and exit
                   --version, -v   print version and exit
                   --register, -r  register SQLcl command tvdformat and exit

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatHelpTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatHelpTest.java
@@ -27,6 +27,11 @@ public class TvdFormatHelpTest extends AbstractSqlclTest {
               ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined
                               per line. Each line represent a glob pattern. Empty lines and lines starting
                               with a hash sign (#) are ignored.
+              serr=<scope>    scope of syntax errors to be reported. By default all errors are reported.
+                              serr=none reports no syntax errors
+                              serr=all reports all syntax errors
+                              serr=ext reports syntax errors for files defined with ext option
+                              serr=mext reports syntax errors for files defined with mext option
               --help, -h,     print this help screen and exit
               --version, -v   print version and exit
 

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatTest.java
@@ -107,4 +107,24 @@ public class TvdFormatTest extends AbstractFormatTest {
     public void process_sql_txt_force() {
         process_sql_txt_force(RunType.TvdFormatCommand);
     }
+
+    @Test
+    public void process_dir_all_errors() {
+        process_dir_all_errors(RunType.TvdFormatCommand);
+    }
+
+    @Test
+    public void process_dir_mext_errors() {
+        process_dir_mext_errors(RunType.TvdFormatCommand);
+    }
+
+    @Test
+    public void process_dir_ext_errors() {
+        process_dir_ext_errors(RunType.TvdFormatCommand);
+    }
+
+    @Test
+    public void process_dir_no_errors() {
+        process_dir_no_errors(RunType.TvdFormatCommand);
+    }
 }

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatTest.java
@@ -99,12 +99,12 @@ public class TvdFormatTest extends AbstractFormatTest {
     }
 
     @Test
-    public void process_sql_txt_default() throws IOException {
+    public void process_sql_txt_default() {
         process_sql_txt_default(RunType.TvdFormatCommand);
     }
 
     @Test
-    public void process_sql_txt_force() throws IOException {
+    public void process_sql_txt_force() {
         process_sql_txt_force(RunType.TvdFormatCommand);
     }
 }

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatWrongArgumentTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/TvdFormatWrongArgumentTest.java
@@ -38,6 +38,11 @@ public class TvdFormatWrongArgumentTest extends AbstractSqlclTest {
                   ignore=<file>   path to the file containing file patterns to ignore. Patterns are defined
                                   per line. Each line represent a glob pattern. Empty lines and lines starting
                                   with a hash sign (#) are ignored.
+                  serr=<scope>    scope of syntax errors to be reported. By default all errors are reported.
+                                  serr=none reports no syntax errors
+                                  serr=all reports all syntax errors
+                                  serr=ext reports syntax errors for files defined with ext option
+                                  serr=mext reports syntax errors for files defined with mext option
                   --help, -h,     print this help screen and exit
                   --version, -v   print version and exit
 


### PR DESCRIPTION
closes #229

- new option serr to control reporting of syntax errors
- update SQLcl to 22.2.1
- show processing information per SQL code block in markdown files