### PR TITLE
Feature/issue 228 detect charset

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Test file encoded in windows-1252
+windows-1252.sql encoding=cp1252

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -51,7 +51,7 @@ The parameters are the same as for the [executable JAR](#executable-jar).
 
 ## How to Build
 
-1. [Download](https://www.oracle.com/tools/downloads/sqlcl-downloads.html) and install SQLcl 22.2.0
+1. [Download](https://www.oracle.com/tools/downloads/sqlcl-downloads.html) and install SQLcl 22.2.1
 2. [Download](https://github.com/graalvm/graalvm-ce-builds/releases) and install the GraalVM JDK 17 22.2.0
 3. Go to the `bin` directory of the GraalVM JDK and run `./gu install js native-image`, if you want to produce a native image
 4. [Download](https://maven.apache.org/download.cgi) and install Apache Maven 3.8.6

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -386,6 +386,10 @@
                                     <classpath>
                                         ${project.build.directory}/${project.build.finalName}.jar:${settings.localRepository}/oracle/dbtools/dbtools-common/${sqlcl.version}/dbtools-common-${sqlcl.version}.jar:${settings.localRepository}/org/reflections/reflections/${reflections.version}/reflections-${reflections.version}.jar:${settings.localRepository}/org/javassist/javassist/${javassist.version}/javassist-${javassist.version}.jar:${settings.localRepository}/org/slf4j/slf4j-api/${slf4j.version}/slf4j-api-${slf4j.version}.jar:${settings.localRepository}/org/slf4j/slf4j-jdk14/${slf4j.version}/slf4j-jdk14-${slf4j.version}.jar:${settings.localRepository}/org/graalvm/js/js-scriptengine/${graalvm.version}/js-scriptengine-${graalvm.version}.jar
                                     </classpath>
+                                    <buildArgs combine.children="append">
+                                        <!-- including all charsets works for build-native only!?! -->
+                                        <buildArg>-H:+AddAllCharsets</buildArg>
+                                    </buildArgs>
                                 </configuration>
                             </execution>
                         </executions>

--- a/standalone/src/main/resources/META-INF/native-image/com.trivadis.plsql.formatter/tvdformat/reflect-config.json
+++ b/standalone/src/main/resources/META-INF/native-image/com.trivadis.plsql.formatter/tvdformat/reflect-config.json
@@ -125,6 +125,28 @@
     "allPublicClasses": true
   },
   {
+    "name": "java.nio.ByteBuffer",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicClasses": true
+  },
+  {
+    "name": "java.nio.charset.Charset",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicClasses": true
+  },
+  {
     "name": "java.nio.file.Files",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
@@ -181,6 +203,17 @@
   },
   {
     "name": "java.util.Collection",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicClasses": true
+  },
+  {
+    "name": "java.util.Collections$UnmodifiableSortedMap",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true,
@@ -258,6 +291,17 @@
   },
   {
     "name": "java.util.regex.Pattern",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicClasses": true
+  },
+  {
+    "name": "java.util.SortedMap",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true,
@@ -542,5 +586,38 @@
   },
   {
     "name": "org.graalvm.polyglot.management.Management"
+  },
+  {
+    "name": "sun.nio.cs.MS1252$Holder",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicClasses": true
+  },
+  {
+    "name": "sun.nio.cs.SingleByte$Decoder",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicClasses": true
+  },
+  {
+    "name": "sun.nio.cs.UTF_8$Decoder",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicClasses": true
   }
 ]

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractSqlclTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/AbstractSqlclTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Predicate;
 import java.util.logging.LogManager;
-import java.util.stream.Collectors;
 
 public abstract class AbstractSqlclTest {
     static {
@@ -49,6 +48,7 @@ public abstract class AbstractSqlclTest {
         setup();
     }
 
+    @SuppressWarnings("resource")
     @BeforeEach
     public void setup() {
         byteArrayOutputStream.reset();
@@ -68,8 +68,7 @@ public abstract class AbstractSqlclTest {
             var url = Thread.currentThread().getContextClassLoader().getResource("unformatted");
             assert url != null;
             var unformattedDir = Paths.get(url.getPath());
-            var sources = Files.walk(unformattedDir).filter(Files::isRegularFile)
-                    .collect(Collectors.toList());
+            var sources = Files.walk(unformattedDir).filter(Files::isRegularFile).toList();
             for (Path source : sources) {
                 Path target = Paths.get(tempDir.toString() + File.separator + source.getFileName());
                 Files.copy(source, target);

--- a/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/CharsetTest.java
+++ b/standalone/src/test/java/com/trivadis/plsql/formatter/sqlcl/tests/CharsetTest.java
@@ -1,0 +1,119 @@
+package com.trivadis.plsql.formatter.sqlcl.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class CharsetTest extends AbstractSqlclTest {
+
+    @SuppressWarnings({"ResultOfMethodCallIgnored", "resource"})
+    @BeforeEach
+    public void setup() {
+        try {
+            super.setup();
+            Files.walk(tempDir).filter(Files::isRegularFile).map(Path::toFile).forEach(File::delete);
+            var url = Thread.currentThread().getContextClassLoader().getResource("charset");
+            assert url != null;
+            var dir = Paths.get(url.getPath());
+            var sources = Files.walk(dir).filter(Files::isRegularFile).toList();
+            for (Path source : sources) {
+                Path target = Paths.get(tempDir.toString() + File.separator + source.getFileName());
+                Files.copy(source, target);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Path sourceFile(String fileName) {
+        var url = Thread.currentThread().getContextClassLoader().getResource("charset/" + fileName);
+        assert url != null;
+        return Paths.get(url.getPath());
+    }
+
+    @Nested
+    class FormatJS {
+
+        public boolean isSameAsOriginalContent(String fileName) {
+            var sourceFile = sourceFile(fileName);
+            var targetFile = Paths.get(tempDir.toString() + File.separator + fileName);
+            try {
+                return Files.mismatch(sourceFile, targetFile) == -1;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test
+        public void formatUtf8() {
+            var actual = runScript(tempDir.toString() + File.separator + "utf8.sql");
+            Assertions.assertNotNull(actual);
+            Assertions.assertTrue(isSameAsOriginalContent("utf8.sql"));
+        }
+
+        @Test
+        public void formatWindows1252() {
+            var actual = runScript(tempDir.toString() + File.separator + "windows-1252.sql");
+            Assertions.assertNotNull(actual);
+            Assertions.assertTrue(isSameAsOriginalContent("windows-1252.sql"));
+        }
+    }
+
+    @Nested
+    class DetectCharsetJava {
+
+        private Charset detectCharset(byte[] content) {
+            try {
+                // try default character set of the OS (can be overridden via -Dfile.encoding)
+                var cs = Charset.defaultCharset();
+                cs.newDecoder().decode(ByteBuffer.wrap(content));
+                return cs;
+            } catch (CharacterCodingException e) {
+                // default is not working, try another character set
+                // rudimentary solution since Apache Tika cannot be used in SQLcl
+                for (Charset cs : Charset.availableCharsets().values().stream().filter(
+                        it -> !it.name().equals(Charset.defaultCharset().name())
+                                && (it.name().equals("UTF-8") || it.name().equals("windows-1252")
+                        )).toList()) {
+                    try {
+                        cs.newDecoder().decode(ByteBuffer.wrap(content));
+                        return cs;
+                    } catch (CharacterCodingException ex) {
+                        return null;
+                    }
+                }
+                return null;
+            }
+        }
+
+        @Test
+        public void detect_windows_1252() throws IOException {
+            Charset.forName("windows-1252");
+            var file = sourceFile("windows-1252.sql");
+            var content = Files.readAllBytes(file);
+            var actual = detectCharset(content);
+            Assertions.assertNotNull(actual);
+            Assertions.assertEquals("windows-1252", actual.name());
+        }
+
+        @Test
+        public void detect_utf_8() throws IOException {
+            Charset.forName("UTF-8");
+            var file = sourceFile("utf8.sql");
+            var content = Files.readAllBytes(file);
+            var actual = detectCharset(content);
+            Assertions.assertNotNull(actual);
+            Assertions.assertEquals("UTF-8", actual.name());
+        }
+    }
+}

--- a/standalone/src/test/resources/charset/utf8.sql
+++ b/standalone/src/test/resources/charset/utf8.sql
@@ -1,0 +1,6 @@
+begin
+   dbms_output.put_line('Ää-Öö-Üü-Éé-Èè');
+   dbms_output.put_line('£100');
+   dbms_output.put_line('€200');
+end;
+/

--- a/standalone/src/test/resources/charset/windows-1252.sql
+++ b/standalone/src/test/resources/charset/windows-1252.sql
@@ -1,0 +1,6 @@
+begin
+   dbms_output.put_line('Ää-Öö-Üü-Éé-Èè');
+   dbms_output.put_line('£100');
+   dbms_output.put_line('€200');
+end;
+/


### PR DESCRIPTION
#closes 228

- Simple algorithm to detect character set in files to be formatted
    1. Try OS specific character set which can be overridden by `-Dfile.encoding`
    2. Try UTF-8
    3. Try Windows-1252
    4. do not format file, show `skipped due to unknown character set.`
- Updated native image to support additional classes loaded dynamically